### PR TITLE
[Feature] Add compact forum explore UI

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -201,6 +201,12 @@ def register():
 def test_base():
     return render_template("test_base.html")
 
+# ---------- Forum ----------
+@main.route("/forum")
+@login_required
+def forum():
+    return render_template("forum.html")
+
 # ---------- StudyBuddy ----------
 @main.route("/studybuddy")
 @login_required

--- a/app/static/css/forum.css
+++ b/app/static/css/forum.css
@@ -274,14 +274,9 @@
   text-decoration: underline;
 }
 
-/* Footer row: icons left, tags right */
+/* Footer row: icons and tags left-aligned */
 
 .thread-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-
   margin-top: 8px;
 }
 
@@ -344,13 +339,12 @@
 /* Tags */
 
 .thread-tags {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: flex-end;
   flex-wrap: wrap;
   gap: 5px;
 
-  margin-top: 0;
+  margin-left: 6px;
   min-width: 0;
 }
 
@@ -483,14 +477,8 @@
     font-size: 0.94rem;
   }
 
-  .thread-footer {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-  }
-
   .thread-tags {
-    justify-content: flex-start;
+    margin-left: 0;
   }
 
   .thread-body {

--- a/app/static/css/forum.css
+++ b/app/static/css/forum.css
@@ -1,0 +1,499 @@
+/* =========================
+   FORUM PAGE
+========================= */
+
+.forum-page {
+  width: min(calc(100% - 12px), 1460px);
+  margin: 0;
+
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+
+  --forum-title: #f2f5f8;
+  --forum-meta: #a9bacb;
+  --forum-action: #b5c7d8;
+  --forum-action-hover: #eef4fa;
+  --forum-divider: rgba(185, 200, 214, 0.18);
+  --forum-card-hover: rgba(255, 255, 255, 0.035);
+  --forum-pill-bg: #242b31;
+  --forum-tag-bg: rgba(90, 105, 255, 0.18);
+  --forum-tag-text: #8fa0ff;
+  --forum-body: #c8d3df;
+}
+
+.forum-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
+  gap: 28px;
+  align-items: start;
+}
+
+.forum-main {
+  min-width: 0;
+}
+
+.forum-right-panel {
+  min-height: calc(100vh - var(--topbar-height) - 80px);
+}
+
+.forum-right-placeholder {
+  position: sticky;
+  top: calc(var(--topbar-height) + 16px);
+
+  min-height: 360px;
+
+  border: 1px dashed rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+/* =========================
+   TOOLBAR + DROPDOWNS
+========================= */
+
+.forum-toolbar {
+  position: sticky;
+  top: var(--topbar-height);
+  z-index: 40;
+
+  display: flex;
+  align-items: center;
+  gap: 18px;
+
+  padding: 6px 0 8px;
+
+  background: var(--bg-main);
+  border-bottom: 1px solid var(--forum-divider);
+}
+
+.forum-dropdown {
+  position: relative;
+}
+
+.forum-control-button {
+  min-height: 34px;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+
+  padding: 0 9px;
+
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--forum-action);
+
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+
+  transition:
+    background 0.16s ease,
+    border-color 0.16s ease,
+    color 0.16s ease;
+}
+
+.forum-control-button:hover,
+.forum-control-button[aria-expanded="true"] {
+  background: var(--forum-pill-bg);
+  border-color: var(--forum-divider);
+  color: var(--forum-action-hover);
+}
+
+.forum-control-button i {
+  font-size: 0.98rem;
+}
+
+.forum-chevron {
+  font-size: 0.78rem !important;
+  opacity: 0.78;
+}
+
+.forum-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 80;
+
+  width: 260px;
+  padding: 7px;
+
+  border: 1px solid var(--forum-divider);
+  border-radius: 14px;
+  background: var(--bg-panel);
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.45);
+}
+
+.forum-dropdown-menu[hidden] {
+  display: none;
+}
+
+.forum-dropdown-item {
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  padding: 10px;
+
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--forum-title);
+
+  text-align: left;
+}
+
+.forum-dropdown-item:hover,
+.forum-dropdown-item.is-active {
+  background: var(--forum-pill-bg);
+}
+
+.forum-dropdown-item i {
+  width: 22px;
+  color: var(--forum-action);
+  font-size: 1.05rem;
+}
+
+.forum-dropdown-item strong,
+.forum-dropdown-item small {
+  display: block;
+  line-height: 1.25;
+}
+
+.forum-dropdown-item strong {
+  font-size: 0.88rem;
+}
+
+.forum-dropdown-item small {
+  margin-top: 2px;
+  color: var(--forum-meta);
+  font-size: 0.74rem;
+}
+
+/* =========================
+   THREAD FEED
+========================= */
+
+.forum-feed {
+  display: flex;
+  flex-direction: column;
+
+  margin-left: -18px;
+  padding-left: 18px;
+}
+
+.thread-card {
+  padding: 10px 4px 10px;
+  border-bottom: 1px solid var(--forum-divider);
+
+  transition: background 0.14s ease;
+}
+
+.thread-card:hover,
+.thread-card.is-expanded {
+  background: var(--forum-card-hover);
+}
+
+.thread-content {
+  min-width: 0;
+  padding-left: 2px;
+}
+
+/* Thread text */
+
+.thread-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+
+  color: var(--forum-meta);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.thread-category,
+.thread-author {
+  color: var(--forum-meta);
+}
+
+.thread-dot {
+  color: rgba(169, 186, 203, 0.65);
+}
+
+.thread-pinned {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+
+  color: #f4c95d;
+  font-weight: 750;
+}
+
+.thread-title {
+  display: inline-block;
+  margin-top: 3px;
+
+  color: var(--forum-title);
+
+  font-size: 1rem;
+  font-weight: 780;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+}
+
+.thread-title:hover {
+  text-decoration: underline;
+}
+
+.thread-body {
+  width: 100%;
+  max-width: none;
+  margin: 12px 0 0;
+
+  color: var(--forum-body);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.thread-body[hidden] {
+  display: none !important;
+}
+
+.thread-body-link {
+  color: var(--forum-tag-text);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.thread-body-link:hover {
+  text-decoration: underline;
+}
+
+/* Footer row: icons left, tags right */
+
+.thread-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+
+  margin-top: 8px;
+}
+
+.thread-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+
+  min-width: 0;
+
+  color: var(--forum-action);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.thread-action {
+  min-height: 30px;
+
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+
+  padding: 0 10px;
+
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+
+  line-height: 1;
+  text-decoration: none;
+}
+
+.thread-action:hover {
+  background: var(--forum-pill-bg);
+  color: var(--forum-action-hover);
+}
+
+.thread-action i {
+  font-size: 0.98rem;
+}
+
+.thread-expand-button {
+  width: 34px;
+  padding: 0;
+  justify-content: center;
+}
+
+.thread-like-button {
+  background: var(--forum-pill-bg);
+  color: var(--forum-action-hover);
+}
+
+.thread-like-button.is-liked,
+.thread-save-button.is-saved {
+  color: var(--forum-tag-text);
+}
+
+/* Tags */
+
+.thread-tags {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 5px;
+
+  margin-top: 0;
+  min-width: 0;
+}
+
+.thread-tag {
+  min-height: 21px;
+
+  display: inline-flex;
+  align-items: center;
+
+  padding: 0 8px;
+
+  border-radius: 999px;
+  background: var(--forum-tag-bg);
+  color: var(--forum-tag-text);
+
+  font-size: 0.72rem;
+  font-weight: 750;
+}
+
+/* =========================
+   PLACEHOLDER + LOADING
+========================= */
+
+.forum-placeholder-card {
+  padding: 18px 4px;
+  border-bottom: 1px solid var(--forum-divider);
+}
+
+.forum-placeholder-title {
+  margin: 0 0 5px;
+  color: var(--forum-title);
+  font-size: 0.98rem;
+  font-weight: 750;
+}
+
+.forum-placeholder-text {
+  margin: 0;
+  color: var(--forum-meta);
+  font-size: 0.86rem;
+}
+
+.forum-feed-sentinel {
+  min-height: 90px;
+
+  display: grid;
+  place-items: center;
+
+  color: var(--forum-meta);
+}
+
+.forum-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+
+  padding: 14px 0;
+
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.forum-loading[hidden],
+.forum-end-message[hidden] {
+  display: none;
+}
+
+.forum-spinner {
+  width: 17px;
+  height: 17px;
+
+  border: 2px solid var(--forum-divider);
+  border-top-color: var(--forum-tag-text);
+  border-radius: 999px;
+
+  animation: forum-spin 0.75s linear infinite;
+}
+
+.forum-end-message {
+  margin: 16px 0;
+  color: var(--forum-meta);
+  font-size: 0.86rem;
+}
+
+@keyframes forum-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* =========================
+   RESPONSIVE
+========================= */
+
+@media (max-width: 1180px) {
+  .forum-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .forum-right-panel {
+    display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .forum-page {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .forum-toolbar {
+    top: 72px;
+    gap: 10px;
+    overflow-x: auto;
+  }
+
+  .forum-control-button {
+    white-space: nowrap;
+  }
+
+  .forum-feed {
+    margin-left: -6px;
+    padding-left: 6px;
+  }
+
+  .thread-card {
+    padding: 10px 0;
+  }
+
+  .thread-title {
+    font-size: 0.94rem;
+  }
+
+  .thread-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .thread-tags {
+    justify-content: flex-start;
+  }
+
+  .thread-body {
+    font-size: 0.84rem;
+  }
+}

--- a/app/static/js/forum.js
+++ b/app/static/js/forum.js
@@ -1,0 +1,591 @@
+// =========================
+// FORUM EXPLORE FEED
+// =========================
+
+document.addEventListener("DOMContentLoaded", function () {
+  const feed = document.querySelector("#forumFeed");
+  const sentinel = document.querySelector("#forumFeedSentinel");
+  const loading = document.querySelector("#forumLoading");
+  const endMessage = document.querySelector("#forumEndMessage");
+
+  if (!feed || !sentinel) return;
+
+  const PAGE_SIZE = 20;
+
+  let currentPage = 0;
+  let currentSort = "recent";
+  let currentView = "explore";
+  let isLoading = false;
+  let hasMore = true;
+
+  // Temporary mock data for UI development.
+  // Later, replace loadThreads() with fetch() from Flask.
+  const mockThreads = buildMockThreads(100);
+
+  // -------------------------
+  // Dropdown behaviour
+  // -------------------------
+  const dropdowns = document.querySelectorAll("[data-dropdown]");
+
+  dropdowns.forEach(function (dropdown) {
+    const toggle = dropdown.querySelector("[data-dropdown-toggle]");
+    const menu = dropdown.querySelector("[data-dropdown-menu]");
+
+    if (!toggle || !menu) return;
+
+    toggle.addEventListener("click", function (event) {
+      event.stopPropagation();
+
+      const isOpen = !menu.hidden;
+      closeAllDropdowns();
+
+      menu.hidden = isOpen;
+      toggle.setAttribute("aria-expanded", String(!isOpen));
+    });
+
+    menu.addEventListener("click", function (event) {
+      event.stopPropagation();
+    });
+  });
+
+  document.addEventListener("click", function () {
+    closeAllDropdowns();
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      closeAllDropdowns();
+    }
+  });
+
+  function closeAllDropdowns() {
+    dropdowns.forEach(function (dropdown) {
+      const toggle = dropdown.querySelector("[data-dropdown-toggle]");
+      const menu = dropdown.querySelector("[data-dropdown-menu]");
+
+      if (!toggle || !menu) return;
+
+      menu.hidden = true;
+      toggle.setAttribute("aria-expanded", "false");
+    });
+  }
+
+  // -------------------------
+  // View selection
+  // -------------------------
+  document.querySelectorAll("[data-view-option]").forEach(function (button) {
+    button.addEventListener("click", function () {
+      const nextView = button.dataset.viewOption;
+
+      document.querySelectorAll("[data-view-option]").forEach(function (item) {
+        item.classList.remove("is-active");
+      });
+
+      button.classList.add("is-active");
+
+      const label = document.querySelector("[data-view-label]");
+      if (label) {
+        label.textContent = nextView === "categories" ? "Categories" : "Explore";
+      }
+
+      currentView = nextView;
+      closeAllDropdowns();
+
+      if (currentView === "categories") {
+        showCategoryPlaceholder();
+      } else {
+        resetAndLoad();
+      }
+    });
+  });
+
+  function showCategoryPlaceholder() {
+    feed.innerHTML = `
+      <div class="forum-placeholder-card">
+        <p class="forum-placeholder-title">Category view will be added next.</p>
+        <p class="forum-placeholder-text">
+          For now, this screen focuses on the compact Explore feed.
+        </p>
+      </div>
+    `;
+
+    hasMore = false;
+
+    if (loading) loading.hidden = true;
+    if (endMessage) endMessage.hidden = true;
+  }
+
+  // -------------------------
+  // Sort selection
+  // -------------------------
+  document.querySelectorAll("[data-sort-option]").forEach(function (button) {
+    button.addEventListener("click", function () {
+      const nextSort = button.dataset.sortOption;
+      const labelText =
+        button.querySelector("strong")?.textContent || "Recently Active";
+
+      document.querySelectorAll("[data-sort-option]").forEach(function (item) {
+        item.classList.remove("is-active");
+      });
+
+      button.classList.add("is-active");
+
+      const label = document.querySelector("[data-sort-label]");
+      if (label) {
+        label.textContent = labelText;
+      }
+
+      currentSort = nextSort;
+      currentView = "explore";
+
+      const viewLabel = document.querySelector("[data-view-label]");
+      if (viewLabel) {
+        viewLabel.textContent = "Explore";
+      }
+
+      document.querySelectorAll("[data-view-option]").forEach(function (item) {
+        item.classList.toggle(
+          "is-active",
+          item.dataset.viewOption === "explore"
+        );
+      });
+
+      closeAllDropdowns();
+      resetAndLoad();
+    });
+  });
+
+  // -------------------------
+  // Thread card interactions
+  // -------------------------
+  feed.addEventListener("click", function (event) {
+    const expandButton = event.target.closest("[data-expand-thread]");
+    const likeButton = event.target.closest("[data-like-thread]");
+    const saveButton = event.target.closest("[data-save-thread]");
+
+    if (expandButton) {
+      toggleThreadExpansion(expandButton);
+      return;
+    }
+
+    if (likeButton) {
+      toggleThreadLike(likeButton);
+      return;
+    }
+
+    if (saveButton) {
+      toggleThreadSave(saveButton);
+    }
+  });
+
+  function toggleThreadExpansion(button) {
+    const card = button.closest(".thread-card");
+    if (!card) return;
+
+    const body = card.querySelector(".thread-body");
+    const icon = button.querySelector("i");
+
+    const isExpanded = button.getAttribute("aria-expanded") === "true";
+    const nextExpanded = !isExpanded;
+
+    button.setAttribute("aria-expanded", String(nextExpanded));
+    button.setAttribute(
+      "aria-label",
+      nextExpanded ? "Collapse thread" : "Expand thread"
+    );
+
+    card.classList.toggle("is-expanded", nextExpanded);
+
+    if (body) {
+      body.hidden = !nextExpanded;
+    }
+
+    if (icon) {
+      icon.className = nextExpanded
+        ? "bi bi-x-lg"
+        : "bi bi-arrows-angle-expand";
+    }
+  }
+
+  function toggleThreadLike(button) {
+    const countElement = button.querySelector("[data-like-count]");
+    const icon = button.querySelector("i");
+
+    const isLiked = button.classList.toggle("is-liked");
+    const currentCount = Number(countElement?.textContent || 0);
+    const nextCount = isLiked ? currentCount + 1 : Math.max(0, currentCount - 1);
+
+    if (countElement) {
+      countElement.textContent = String(nextCount);
+    }
+
+    if (icon) {
+      icon.className = isLiked
+        ? "bi bi-hand-thumbs-up-fill"
+        : "bi bi-hand-thumbs-up";
+    }
+
+    button.setAttribute("aria-pressed", String(isLiked));
+  }
+
+  function toggleThreadSave(button) {
+    const icon = button.querySelector("i");
+    const isSaved = button.classList.toggle("is-saved");
+
+    if (icon) {
+      icon.className = isSaved ? "bi bi-bookmark-fill" : "bi bi-bookmark";
+    }
+
+    button.setAttribute("aria-pressed", String(isSaved));
+    button.setAttribute("aria-label", isSaved ? "Unsave thread" : "Save thread");
+  }
+
+  // -------------------------
+  // Infinite loading
+  // -------------------------
+  const observer = new IntersectionObserver(
+    function (entries) {
+      const entry = entries[0];
+
+      if (
+        entry.isIntersecting &&
+        hasMore &&
+        !isLoading &&
+        currentView === "explore"
+      ) {
+        loadNextPage();
+      }
+    },
+    {
+      root: null,
+      rootMargin: "650px 0px",
+      threshold: 0
+    }
+  );
+
+  observer.observe(sentinel);
+
+  function resetAndLoad() {
+    currentPage = 0;
+    hasMore = true;
+    isLoading = false;
+
+    feed.innerHTML = "";
+
+    if (endMessage) endMessage.hidden = true;
+
+    loadNextPage();
+  }
+
+  async function loadNextPage() {
+    if (isLoading || !hasMore) return;
+
+    isLoading = true;
+    if (loading) loading.hidden = false;
+
+    try {
+      const threads = await loadThreads({
+        page: currentPage + 1,
+        pageSize: PAGE_SIZE,
+        sort: currentSort
+      });
+
+      if (threads.length < PAGE_SIZE) {
+        hasMore = false;
+      }
+
+      currentPage += 1;
+      renderThreads(threads);
+
+      if (!hasMore && endMessage) {
+        endMessage.hidden = false;
+      }
+    } catch (error) {
+      console.error("Failed to load forum threads:", error);
+      renderErrorMessage();
+      hasMore = false;
+    } finally {
+      isLoading = false;
+      if (loading) loading.hidden = true;
+    }
+  }
+
+  async function loadThreads({ page, pageSize, sort }) {
+    // Later Flask API version:
+    //
+    // const response = await fetch(
+    //   `/forum/api/threads?sort=${encodeURIComponent(sort)}&page=${page}&page_size=${pageSize}`
+    // );
+    //
+    // if (!response.ok) throw new Error("Failed to fetch threads");
+    // const data = await response.json();
+    // hasMore = data.has_more;
+    // return data.threads;
+
+    await wait(250);
+
+    const sortedThreads = getSortedThreads(mockThreads, sort);
+
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+
+    return sortedThreads.slice(start, end);
+  }
+
+  function renderThreads(threads) {
+    const fragment = document.createDocumentFragment();
+
+    threads.forEach(function (thread) {
+      const article = document.createElement("article");
+      article.className = "thread-card";
+      article.dataset.threadId = String(thread.id);
+
+      article.innerHTML = `
+        <div class="thread-content">
+          <div class="thread-meta">
+            ${
+              thread.isPinned
+                ? `<span class="thread-pinned">
+                     <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
+                     Pinned
+                   </span>
+                   <span class="thread-dot">·</span>`
+                : ""
+            }
+
+            <span class="thread-category">${escapeHTML(thread.category)}</span>
+            <span class="thread-dot">·</span>
+            <span class="thread-author">Posted by ${escapeHTML(thread.author)}</span>
+            <span class="thread-dot">·</span>
+            <span>${escapeHTML(thread.timeAgo)}</span>
+          </div>
+
+          <a href="${escapeHTML(thread.url)}" class="thread-title">
+            ${escapeHTML(thread.title)}
+          </a>
+
+          <div class="thread-footer">
+            <div class="thread-actions">
+              <button
+                class="thread-action thread-expand-button"
+                type="button"
+                aria-label="Expand thread"
+                aria-expanded="false"
+                data-expand-thread
+              >
+                <i class="bi bi-arrows-angle-expand" aria-hidden="true"></i>
+              </button>
+
+              <button
+                class="thread-action thread-like-button"
+                type="button"
+                aria-label="Like thread"
+                aria-pressed="false"
+                data-like-thread
+              >
+                <i class="bi bi-hand-thumbs-up" aria-hidden="true"></i>
+                <span data-like-count>${thread.likeCount}</span>
+              </button>
+
+              <a href="${escapeHTML(thread.url)}#comments" class="thread-action thread-comments-link">
+                <span>${thread.commentCount} comments</span>
+              </a>
+
+              <button
+                class="thread-action thread-save-button"
+                type="button"
+                aria-label="Save thread"
+                aria-pressed="false"
+                data-save-thread
+              >
+                <i class="bi bi-bookmark" aria-hidden="true"></i>
+              </button>
+            </div>
+
+            <div class="thread-tags">
+              ${thread.tags
+                .map(function (tag) {
+                  return `<span class="thread-tag">#${escapeHTML(tag)}</span>`;
+                })
+                .join("")}
+            </div>
+          </div>
+
+          <p class="thread-body" hidden>
+            ${formatText(thread.body)}
+          </p>
+        </div>
+      `;
+
+      fragment.appendChild(article);
+    });
+
+    feed.appendChild(fragment);
+  }
+
+  function renderErrorMessage() {
+    const errorCard = document.createElement("div");
+    errorCard.className = "forum-placeholder-card";
+
+    errorCard.innerHTML = `
+      <p class="forum-placeholder-title">Unable to load more discussions</p>
+      <p class="forum-placeholder-text">Please refresh the page and try again.</p>
+    `;
+
+    feed.appendChild(errorCard);
+  }
+
+  function getSortedThreads(threads, sort) {
+    const copy = [...threads];
+
+    let sorted;
+
+    if (sort === "popular") {
+      sorted = copy.sort(function (a, b) {
+        const scoreA = a.likeCount * 2 + a.commentCount;
+        const scoreB = b.likeCount * 2 + b.commentCount;
+        return scoreB - scoreA;
+      });
+    } else if (sort === "new") {
+      sorted = copy.sort(function (a, b) {
+        return b.createdAt - a.createdAt;
+      });
+    } else {
+      sorted = copy.sort(function (a, b) {
+        return b.lastActivityAt - a.lastActivityAt;
+      });
+    }
+
+    return sorted.sort(function (a, b) {
+      if (a.isPinned && !b.isPinned) return -1;
+      if (!a.isPinned && b.isPinned) return 1;
+      return 0;
+    });
+  }
+
+  function buildMockThreads(count) {
+    const authors = [
+      "Hans",
+      "Alice",
+      "Daniel",
+      "Maya",
+      "Kevin",
+      "Sarah",
+      "Tutor Alex"
+    ];
+
+    const dummyCategories = [
+      "General",
+      "AI & Data Science",
+      "Software Engineering",
+      "Computer Science",
+      "Courses & Study Help"
+    ];
+
+    const featuredThreads = [
+      {
+        type: "discussion",
+        category: "General",
+        title: "How are you preparing for the CITS5508 Machine Learning exam?",
+        body:
+          "How are you preparing for the CITS5508 Machine Learning exam since there’s no cheat sheet allowed? Any tips appreciated.\n\nInspired by a real r/UWA thread: https://www.reddit.com/r/uwa/comments/1t1jad6/cits_5508_machine_learning/",
+        tags: ["study-tips", "cits5508", "exam-prep"]
+      },
+      {
+        type: "question",
+        category: "Software Engineering",
+        title: "I still do not really understand Model-View-Controller",
+        body:
+          "I keep seeing Model-View-Controller explained as Model for data, View for UI, and Controller for application logic. But in our actual Flask project, I am not sure how to map that idea properly. For example, are the SQLAlchemy classes in models.py the Model? Are Jinja templates the View? And are the route functions the Controller? I think I understand the words, but not how the pieces connect in a real codebase.",
+        tags: ["mvc", "flask", "web-development"]
+      },
+      {
+        type: "question",
+        category: "AI & Data Science",
+        title: "I still do not really understand the idea behind PCA",
+        body:
+          "I understand that PCA is used for dimensionality reduction, but I am still confused about the intuition. When we say PCA finds directions of maximum variance, does that mean it is finding the most important features? How should I think about principal components in a simple way, especially when the original dataset has many columns?",
+        tags: ["machine-learning", "pca", "intuition"]
+      }
+    ];
+
+    const threads = [];
+    const now = Date.now();
+
+    for (let i = 1; i <= count; i += 1) {
+      let threadData;
+
+      if (i <= featuredThreads.length) {
+        threadData = featuredThreads[i - 1];
+      } else {
+        const category = dummyCategories[i % dummyCategories.length];
+
+        threadData = {
+          type: "discussion",
+          category: category,
+          title: `Dummy forum thread #${i}`,
+          body:
+            "This is dummy body content for UI testing. Later, this will be replaced by real forum posts from the database. For now, it helps us check spacing, scrolling, sorting, expansion, and card density.",
+          tags: ["dummy", "scroll-test"]
+        };
+      }
+
+      const createdAt = now - i * 1000 * 60 * 60;
+      const lastActivityAt = now - i * 1000 * 60;
+
+      threads.push({
+        id: i,
+        type: threadData.type,
+        title: threadData.title,
+        body: threadData.body,
+        category: threadData.category,
+        author: authors[(i - 1) % authors.length],
+        tags: threadData.tags,
+        likeCount: i <= 3 ? i * 8 + 4 : (i * 7) % 96,
+        commentCount: i <= 3 ? i * 3 + 2 : (i * 3) % 38,
+        isPinned: i === 1,
+        createdAt: createdAt,
+        lastActivityAt: lastActivityAt,
+        timeAgo: makeTimeAgo(i),
+        url: `/forum/thread/${i}`
+      });
+    }
+
+    return threads;
+  }
+
+  function makeTimeAgo(index) {
+    if (index < 2) return "10m ago";
+    if (index < 6) return `${index}h ago`;
+    if (index < 20) return `${Math.floor(index / 2)}d ago`;
+
+    return `${Math.floor(index / 7)}w ago`;
+  }
+
+  function wait(ms) {
+    return new Promise(function (resolve) {
+      window.setTimeout(resolve, ms);
+    });
+  }
+
+  function formatText(value) {
+    const escapedText = escapeHTML(value).replaceAll("\n", "<br>");
+
+    return escapedText.replace(
+      /(https?:\/\/[^\s<]+)/g,
+      '<a class="thread-body-link" href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
+    );
+  }
+
+  function escapeHTML(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  // Initial load
+  resetAndLoad();
+});

--- a/app/static/js/forum.js
+++ b/app/static/js/forum.js
@@ -332,96 +332,96 @@ document.addEventListener("DOMContentLoaded", function () {
     return sortedThreads.slice(start, end);
   }
 
-  function renderThreads(threads) {
-    const fragment = document.createDocumentFragment();
+	function renderThreads(threads) {
+		const fragment = document.createDocumentFragment();
 
-    threads.forEach(function (thread) {
-      const article = document.createElement("article");
-      article.className = "thread-card";
-      article.dataset.threadId = String(thread.id);
+		threads.forEach(function (thread) {
+			const article = document.createElement("article");
+			article.className = "thread-card";
+			article.dataset.threadId = String(thread.id);
 
-      article.innerHTML = `
-        <div class="thread-content">
-          <div class="thread-meta">
-            ${
-              thread.isPinned
-                ? `<span class="thread-pinned">
-                     <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
-                     Pinned
-                   </span>
-                   <span class="thread-dot">·</span>`
-                : ""
-            }
+			article.innerHTML = `
+				<div class="thread-content">
+					<div class="thread-meta">
+						${
+							thread.isPinned
+								? `<span class="thread-pinned">
+										<i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
+										Pinned
+									</span>
+									<span class="thread-dot">·</span>`
+								: ""
+						}
 
-            <span class="thread-category">${escapeHTML(thread.category)}</span>
-            <span class="thread-dot">·</span>
-            <span class="thread-author">Posted by ${escapeHTML(thread.author)}</span>
-            <span class="thread-dot">·</span>
-            <span>${escapeHTML(thread.timeAgo)}</span>
-          </div>
+						<span class="thread-category">${escapeHTML(thread.category)}</span>
+						<span class="thread-dot">·</span>
+						<span class="thread-author">Posted by ${escapeHTML(thread.author)}</span>
+						<span class="thread-dot">·</span>
+						<span>${escapeHTML(thread.timeAgo)}</span>
+					</div>
 
-          <a href="${escapeHTML(thread.url)}" class="thread-title">
-            ${escapeHTML(thread.title)}
-          </a>
+					<a href="${escapeHTML(thread.url)}" class="thread-title">
+						${escapeHTML(thread.title)}
+					</a>
 
-          <div class="thread-footer">
-            <div class="thread-actions">
-              <button
-                class="thread-action thread-expand-button"
-                type="button"
-                aria-label="Expand thread"
-                aria-expanded="false"
-                data-expand-thread
-              >
-                <i class="bi bi-arrows-angle-expand" aria-hidden="true"></i>
-              </button>
+					<div class="thread-footer">
+						<div class="thread-actions">
+							<button
+								class="thread-action thread-expand-button"
+								type="button"
+								aria-label="Expand thread"
+								aria-expanded="false"
+								data-expand-thread
+							>
+								<i class="bi bi-arrows-angle-expand" aria-hidden="true"></i>
+							</button>
 
-              <button
-                class="thread-action thread-like-button"
-                type="button"
-                aria-label="Like thread"
-                aria-pressed="false"
-                data-like-thread
-              >
-                <i class="bi bi-hand-thumbs-up" aria-hidden="true"></i>
-                <span data-like-count>${thread.likeCount}</span>
-              </button>
+							<button
+								class="thread-action thread-like-button"
+								type="button"
+								aria-label="Like thread"
+								aria-pressed="false"
+								data-like-thread
+							>
+								<i class="bi bi-hand-thumbs-up" aria-hidden="true"></i>
+								<span data-like-count>${thread.likeCount}</span>
+							</button>
 
-              <a href="${escapeHTML(thread.url)}#comments" class="thread-action thread-comments-link">
-                <span>${thread.commentCount} comments</span>
-              </a>
+							<a href="${escapeHTML(thread.url)}#comments" class="thread-action thread-comments-link">
+								<span>${thread.commentCount} comments</span>
+							</a>
 
-              <button
-                class="thread-action thread-save-button"
-                type="button"
-                aria-label="Save thread"
-                aria-pressed="false"
-                data-save-thread
-              >
-                <i class="bi bi-bookmark" aria-hidden="true"></i>
-              </button>
-            </div>
+							<button
+								class="thread-action thread-save-button"
+								type="button"
+								aria-label="Save thread"
+								aria-pressed="false"
+								data-save-thread
+							>
+								<i class="bi bi-bookmark" aria-hidden="true"></i>
+							</button>
 
-            <div class="thread-tags">
-              ${thread.tags
-                .map(function (tag) {
-                  return `<span class="thread-tag">#${escapeHTML(tag)}</span>`;
-                })
-                .join("")}
-            </div>
-          </div>
+							<div class="thread-tags">
+								${thread.tags
+									.map(function (tag) {
+										return `<span class="thread-tag">#${escapeHTML(tag)}</span>`;
+									})
+									.join("")}
+							</div>
+						</div>
+					</div>
 
-          <p class="thread-body" hidden>
-            ${formatText(thread.body)}
-          </p>
-        </div>
-      `;
+					<p class="thread-body" hidden>
+						${formatText(thread.body)}
+					</p>
+				</div>
+			`;
 
-      fragment.appendChild(article);
-    });
+			fragment.appendChild(article);
+		});
 
-    feed.appendChild(fragment);
-  }
+		feed.appendChild(fragment);
+	}
 
   function renderErrorMessage() {
     const errorCard = document.createElement("div");

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -124,7 +124,7 @@
             <span class="sidebar-label">News</span>
           </a>
 
-          <a href="#" class="sidebar-link">
+          <a href="{{ url_for('main.forum') }}" class="sidebar-link {% if request.path.startswith('/forum') %}is-active{% endif %}">
             <i class="bi bi-chat-square-text sidebar-icon" aria-hidden="true"></i>
             <span class="sidebar-label">Forum</span>
           </a>

--- a/app/templates/forum.html
+++ b/app/templates/forum.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+
+{% block title %}Forum | CSHub{% endblock %}
+
+{% block styles %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/forum.css') }}">
+{% endblock %}
+
+{% block content %}
+<section class="forum-page" aria-label="CSHub forum">
+  <div class="forum-layout">
+
+    <!-- Main feed area -->
+    <div class="forum-main">
+
+      <!-- Forum toolbar -->
+      <div class="forum-toolbar" aria-label="Forum controls">
+
+        <!-- View mode dropdown -->
+        <div class="forum-dropdown" data-dropdown>
+          <button
+            class="forum-control-button"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            data-dropdown-toggle
+          >
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span data-view-label>Explore</span>
+            <i class="bi bi-chevron-down forum-chevron" aria-hidden="true"></i>
+          </button>
+
+          <div class="forum-dropdown-menu" hidden data-dropdown-menu>
+            <button class="forum-dropdown-item is-active" type="button" data-view-option="explore">
+              <i class="bi bi-compass" aria-hidden="true"></i>
+              <span>
+                <strong>Explore</strong>
+                <small>Browse all discussions</small>
+              </span>
+            </button>
+
+            <button class="forum-dropdown-item" type="button" data-view-option="categories">
+              <i class="bi bi-grid-3x3-gap" aria-hidden="true"></i>
+              <span>
+                <strong>Categories</strong>
+                <small>Browse by topic area</small>
+              </span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Sort dropdown -->
+        <div class="forum-dropdown" data-dropdown>
+          <button
+            class="forum-control-button"
+            type="button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            data-dropdown-toggle
+          >
+            <i class="bi bi-sliders" aria-hidden="true"></i>
+            <span data-sort-label>Recently Active</span>
+            <i class="bi bi-chevron-down forum-chevron" aria-hidden="true"></i>
+          </button>
+
+          <div class="forum-dropdown-menu" hidden data-dropdown-menu>
+            <button class="forum-dropdown-item is-active" type="button" data-sort-option="recent">
+              <i class="bi bi-clock-history" aria-hidden="true"></i>
+              <span>
+                <strong>Recently Active</strong>
+                <small>Latest activity first</small>
+              </span>
+            </button>
+
+            <button class="forum-dropdown-item" type="button" data-sort-option="popular">
+              <i class="bi bi-fire" aria-hidden="true"></i>
+              <span>
+                <strong>Popular</strong>
+                <small>Most liked and discussed</small>
+              </span>
+            </button>
+
+            <button class="forum-dropdown-item" type="button" data-sort-option="new">
+              <i class="bi bi-stars" aria-hidden="true"></i>
+              <span>
+                <strong>New</strong>
+                <small>Newest threads first</small>
+              </span>
+            </button>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Feed -->
+      <div class="forum-feed" id="forumFeed" aria-live="polite"></div>
+
+      <!-- Infinite-scroll sentinel -->
+      <div class="forum-feed-sentinel" id="forumFeedSentinel">
+        <div class="forum-loading" id="forumLoading" hidden>
+          <span class="forum-spinner" aria-hidden="true"></span>
+          <span>Loading more discussions...</span>
+        </div>
+
+        <p class="forum-end-message" id="forumEndMessage" hidden>
+          You have reached the end of the current discussions.
+        </p>
+      </div>
+
+    </div>
+
+    <!-- Right panel placeholder -->
+    <aside class="forum-right-panel" aria-label="Forum side panel">
+      <div class="forum-right-placeholder" aria-hidden="true"></div>
+    </aside>
+
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/forum.js') }}" defer></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

This PR adds the first UI version of the CSHub forum page.

The page currently focuses on the compact Explore feed layout, using mock thread data so the interface and interaction flow can be reviewed before connecting it to the database.

## Changes

- Added the `/forum` page UI using the shared base layout
- Added a compact forum explore feed for browsing discussions efficiently
- Added Explore / Categories view selector UI
- Added Recently Active / Popular / New sort selector UI
- Added mock forum threads for UI testing
- Added automatic loading of more mock threads while scrolling
- Added expandable thread body preview
- Added like, comment, save, and tag display controls
- Improved feed spacing, density, contrast, and dark-theme readability
- Added a blank right-side panel placeholder for future forum widgets

## Notes

- The current feed uses mock data only.
- The Categories view currently shows a placeholder and will be implemented later.
- Backend forum models, database queries, and API routes will be added in a future PR.
 
 
## Tested

- [x] Forum page loads correctly at `/forum`
- [x] Compact forum feed displays mock discussion threads
- [x] Sort dropdown works for:
  - Recently Active
  - Popular
  - New
- [x] Expand icon opens and closes the thread body
- [x] Thumbs-up button toggles correctly and updates the count by +1 / -1
- [x] Save button toggles correctly between saved and unsaved state
- [x] Infinite scroll loads more mock threads when scrolling down
- [x] Categories view shows the temporary placeholder
- [x] No JavaScript errors shown in the browser console during manual testing