### PR TITLE
Improve home dashboard navigation, notifications, and session reminders

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,17 +28,22 @@ def create_database_schema(app):
         from app import models  # noqa: F401
 
         db.create_all()
-        ensure_study_session_location_column()
+        ensure_study_session_columns()
 
 
-def ensure_study_session_location_column():
+def ensure_study_session_columns():
     inspector = inspect(db.engine)
     if "study_session" not in inspector.get_table_names():
         return
 
     columns = {column["name"] for column in inspector.get_columns("study_session")}
+
     if "location" not in columns:
         db.session.execute(text("ALTER TABLE study_session ADD COLUMN location VARCHAR(150)"))
+        db.session.commit()
+
+    if "session_date" not in columns:
+        db.session.execute(text("ALTER TABLE study_session ADD COLUMN session_date DATE"))
         db.session.commit()
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,7 +1,7 @@
 from app.models.associations import joined_sessions, saved_sessions
 from app.models.announcement import Announcement
 from app.models.user import User
-from app.models.studybuddy import StudySession, SessionMessage
+from app.models.studybuddy import SessionMessage, SessionReadState, StudySession
 
 
 __all__ = [
@@ -11,4 +11,5 @@ __all__ = [
     "User",
     "StudySession",
     "SessionMessage",
+    "SessionReadState",
 ]

--- a/app/models/studybuddy.py
+++ b/app/models/studybuddy.py
@@ -38,3 +38,16 @@ class SessionMessage(db.Model):
         "SessionMessage",
         backref=db.backref("parent", remote_side=[id])
     )
+
+
+class SessionReadState(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    session_id = db.Column(db.Integer, db.ForeignKey("study_session.id"), nullable=False)
+    last_read_message_id = db.Column(db.Integer, db.ForeignKey("session_message.id"), nullable=False, default=0)
+    updated_at = db.Column(db.DateTime, server_default=db.func.now(), onupdate=db.func.now())
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "session_id", name="uq_session_read_state_user_session"),
+    )

--- a/app/models/studybuddy.py
+++ b/app/models/studybuddy.py
@@ -10,6 +10,7 @@ class StudySession(db.Model):
 
     host_name = db.Column(db.String(100), nullable=False)
 
+    session_date = db.Column(db.Date)
     day = db.Column(db.String(10), nullable=False)
     time = db.Column(db.String(50), nullable=False)
     mode = db.Column(db.String(20), nullable=False)

--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,42 @@ def get_current_user():
 
     return db.session.get(User, user_id)
 
+
+@main.app_context_processor
+def inject_topbar_notifications():
+    current_user = get_current_user()
+
+    if current_user is None:
+        return {
+            "session_notifications": [],
+            "session_notification_count": 0,
+        }
+
+    joined_session_ids = [study_session.id for study_session in current_user.joined]
+
+    if not joined_session_ids:
+        return {
+            "session_notifications": [],
+            "session_notification_count": 0,
+        }
+
+    notification_query = SessionMessage.query.filter(
+        SessionMessage.session_id.in_(joined_session_ids),
+        SessionMessage.user_id != current_user.id,
+    )
+
+    notification_messages = (
+        notification_query
+        .order_by(SessionMessage.created_at.desc(), SessionMessage.id.desc())
+        .limit(8)
+        .all()
+    )
+
+    return {
+        "session_notifications": notification_messages,
+        "session_notification_count": notification_query.count(),
+    }
+
 def login_required(view_function):
     @wraps(view_function)
     def wrapped_view(*args, **kwargs):

--- a/app/routes.py
+++ b/app/routes.py
@@ -171,7 +171,7 @@ def login():
         session["user_id"] = user.id
         session["username"] = user.username
 
-        return redirect(url_for("main.studybuddy"))
+        return redirect(url_for("main.home"))
 
     return render_template("auth/login.html", error=error)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -369,6 +369,19 @@ def home():
         current_year=today.year,
     )
 
+
+@main.route("/help")
+@login_required
+def help_page():
+    return render_template("help.html")
+
+
+@main.route("/rules")
+@login_required
+def rules():
+    return render_template("rules.html")
+
+
 @main.route("/announcements")
 @login_required
 def announcements():

--- a/app/routes.py
+++ b/app/routes.py
@@ -6,7 +6,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, sessio
 from sqlalchemy import or_
 
 from app import db
-from app.models import Announcement, User, StudySession, SessionMessage
+from app.models import Announcement, User, StudySession, SessionMessage, SessionReadState
 
 main = Blueprint("main", __name__)
 
@@ -39,22 +39,64 @@ def inject_topbar_notifications():
             "session_notification_count": 0,
         }
 
-    notification_query = SessionMessage.query.filter(
-        SessionMessage.session_id.in_(joined_session_ids),
-        SessionMessage.user_id != current_user.id,
-    )
+    read_states = {
+        read_state.session_id: read_state.last_read_message_id
+        for read_state in SessionReadState.query.filter(
+            SessionReadState.user_id == current_user.id,
+            SessionReadState.session_id.in_(joined_session_ids),
+        ).all()
+    }
 
-    notification_messages = (
-        notification_query
+    candidate_messages = (
+        SessionMessage.query.filter(
+            SessionMessage.session_id.in_(joined_session_ids),
+            SessionMessage.user_id != current_user.id,
+        )
         .order_by(SessionMessage.created_at.desc(), SessionMessage.id.desc())
-        .limit(8)
         .all()
     )
 
+    unread_messages = [
+        message
+        for message in candidate_messages
+        if message.id > read_states.get(message.session_id, 0)
+    ]
+
     return {
-        "session_notifications": notification_messages,
-        "session_notification_count": notification_query.count(),
+        "session_notifications": unread_messages[:8],
+        "session_notification_count": len(unread_messages),
     }
+
+
+def mark_session_messages_read(current_user, session_id):
+    latest_message = (
+        SessionMessage.query.filter_by(session_id=session_id)
+        .order_by(SessionMessage.id.desc())
+        .first()
+    )
+
+    if latest_message is None:
+        return
+
+    read_state = SessionReadState.query.filter_by(
+        user_id=current_user.id,
+        session_id=session_id,
+    ).first()
+
+    if read_state is None:
+        read_state = SessionReadState(
+            user_id=current_user.id,
+            session_id=session_id,
+            last_read_message_id=latest_message.id,
+        )
+        db.session.add(read_state)
+    else:
+        read_state.last_read_message_id = max(
+            read_state.last_read_message_id,
+            latest_message.id,
+        )
+
+    db.session.commit()
 
 def login_required(view_function):
     @wraps(view_function)
@@ -537,6 +579,9 @@ def session_detail(session_id):
 
     joined_ids = {u.id for u in session.joined_users}
     is_joined = current_user.id in joined_ids
+
+    if is_joined:
+        mark_session_messages_read(current_user, session.id)
 
     return render_template(
         "session_detail.html",

--- a/app/routes.py
+++ b/app/routes.py
@@ -138,6 +138,10 @@ def make_unique_slug(title):
     return slug
 
 
+def get_day_label(session_date):
+    return session_date.strftime("%a")
+
+
 # ---------- Auth ----------
 @main.route("/")
 def index():
@@ -318,6 +322,7 @@ def home():
 
     joined_sessions = list(current_user.joined)
     saved_sessions = list(current_user.saved)
+    today = date.today()
 
     recent_messages = (
         SessionMessage.query
@@ -347,13 +352,14 @@ def home():
             "id": study_session.id,
             "topic": study_session.topic,
             "day": study_session.day,
+            "date": study_session.session_date.isoformat() if study_session.session_date else None,
             "time": study_session.time,
             "mode": study_session.mode,
             "location": study_session.location,
             "unit_code": study_session.unit_code,
+            "reminder_date": study_session.session_date.isoformat() if study_session.session_date else None,
+            "reminder_label": study_session.session_date.strftime("%d %b %Y") if study_session.session_date else None,
         })
-
-    today = date.today()
 
     return render_template(
         "home.html",
@@ -454,13 +460,13 @@ def create_session():
     topic = request.form.get("topic", "").strip()
     description = request.form.get("description", "").strip()
     host_name = request.form.get("host_name", "").strip()
-    day = request.form.get("day", "").strip()
+    session_date_raw = request.form.get("session_date", "").strip()
     time = request.form.get("time", "").strip()
     mode = request.form.get("mode", "").strip()
     location = request.form.get("location", "").strip()
     capacity_raw = request.form.get("capacity", "").strip()
 
-    if not all([unit_code, topic, description, host_name, day, time, mode, capacity_raw]):
+    if not all([unit_code, topic, description, host_name, session_date_raw, time, mode, capacity_raw]):
         return redirect(url_for("main.studybuddy"))
 
     if mode in {"in-person", "hybrid"} and not location:
@@ -468,6 +474,11 @@ def create_session():
 
     try:
         capacity = int(capacity_raw)
+    except ValueError:
+        return redirect(url_for("main.studybuddy"))
+
+    try:
+        session_date = date.fromisoformat(session_date_raw)
     except ValueError:
         return redirect(url_for("main.studybuddy"))
 
@@ -479,7 +490,8 @@ def create_session():
         topic=topic,
         description=description,
         host_name=host_name,
-        day=day,
+        session_date=session_date,
+        day=get_day_label(session_date),
         time=time,
         mode=mode,
         location=location or None,

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,6 +1,16 @@
+from datetime import date, timedelta
+
 from app import db
 from app.models import Announcement, SessionMessage, StudySession, User
 from app.models.associations import joined_sessions, saved_sessions
+
+
+def upcoming_date(days_from_today):
+    return date.today() + timedelta(days=days_from_today)
+
+
+def day_label(days_from_today):
+    return upcoming_date(days_from_today).strftime("%a")
 
 
 def seed_demo_data(reset=False):
@@ -132,7 +142,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Machine Learning Revision Group",
             description="Review supervised learning, model evaluation, and common exam-style machine learning questions.",
             host_name=varshitha.full_name,
-            day="Mon",
+            session_date=upcoming_date(2),
+            day=day_label(2),
             time="10:00 AM",
             mode="online",
             location=None,
@@ -145,7 +156,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Agile Web Development Sprint",
             description="Work through Flask routes, SQLAlchemy models, Jinja templates, testing, and final project polish.",
             host_name=qiumei.full_name,
-            day="Tue",
+            session_date=upcoming_date(3),
+            day=day_label(3),
             time="2:00 PM",
             mode="hybrid",
             location="EZONE Central 2.03",
@@ -158,7 +170,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Data Warehousing Study Session",
             description="Revise data warehouse design, dimensional modelling, ETL concepts, and analytics workflows.",
             host_name=student.full_name,
-            day="Wed",
+            session_date=upcoming_date(4),
+            day=day_label(4),
             time="4:30 PM",
             mode="in-person",
             location="CSSE: [G09]Computer Lab",
@@ -171,7 +184,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Software Requirements and Design Workshop",
             description="Compare use cases, acceptance criteria, architecture decisions, and UI flow diagrams.",
             host_name=varshitha.full_name,
-            day="Thu",
+            session_date=upcoming_date(5),
+            day=day_label(5),
             time="11:00 AM",
             mode="online",
             location=None,
@@ -184,7 +198,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Artificial Intelligence Problem Solving",
             description="Practise search strategies, knowledge representation, and reasoning problems with classmates.",
             host_name=qiumei.full_name,
-            day="Fri",
+            session_date=upcoming_date(6),
+            day=day_label(6),
             time="3:00 PM",
             mode="hybrid",
             location="EZONE North 1.24",
@@ -197,7 +212,8 @@ def build_demo_sessions(student, lecturer, admin, varshitha, qiumei):
             topic="Computational Modelling Review",
             description="Discuss modelling assumptions, simulation results, and how to explain computational experiments clearly.",
             host_name=lecturer.full_name,
-            day="Sat",
+            session_date=upcoming_date(7),
+            day=day_label(7),
             time="1:00 PM",
             mode="online",
             location=None,

--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -238,6 +238,164 @@ button {
   background: var(--bg-panel-hover);
 }
 
+.notification-dropdown {
+  position: relative;
+}
+
+.notification-button {
+  position: relative;
+}
+
+.notification-badge {
+  position: absolute;
+  top: 3px;
+  right: 2px;
+
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  border: 2px solid var(--bg-main);
+  border-radius: 999px;
+  background: #ff4d6d;
+  color: #ffffff;
+
+  font-size: 0.65rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.notification-menu {
+  position: absolute;
+  top: calc(100% + 12px);
+  right: 0;
+  z-index: 120;
+
+  width: min(380px, calc(100vw - 28px));
+  max-height: min(520px, calc(100vh - 92px));
+  padding: 10px;
+
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--bg-panel);
+
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+  overflow-y: auto;
+}
+
+.notification-menu[hidden] {
+  display: none;
+}
+
+.notification-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+
+  padding: 8px 8px 10px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.notification-menu-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.notification-menu-header span {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.notification-list {
+  display: grid;
+  gap: 4px;
+  padding-top: 8px;
+}
+
+.notification-item {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 12px;
+
+  padding: 10px;
+  border-radius: 10px;
+  color: var(--text-main);
+}
+
+.notification-item:hover {
+  background: var(--bg-panel-hover);
+}
+
+.notification-avatar {
+  width: 36px;
+  height: 36px;
+
+  display: grid;
+  place-items: center;
+
+  border-radius: 999px;
+  background: var(--accent-blue);
+  color: #ffffff;
+
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.notification-copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.notification-copy strong,
+.notification-copy span,
+.notification-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notification-copy strong {
+  font-size: 0.9rem;
+}
+
+.notification-copy span {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.notification-copy small {
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+.notification-empty {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+
+  padding: 28px 18px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.notification-empty i {
+  font-size: 1.35rem;
+}
+
+.notification-empty p {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
 .mobile-search-button {
   display: none;
 }

--- a/app/static/css/home.css
+++ b/app/static/css/home.css
@@ -497,6 +497,44 @@
   line-height: 1.5;
 }
 
+.selected-calendar-info strong {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--home-text);
+  font-size: 13px;
+}
+
+.selected-calendar-info p {
+  margin: 0;
+}
+
+.calendar-reminder-list {
+  display: grid;
+  gap: 8px;
+}
+
+.calendar-reminder-item {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border-radius: 12px;
+  background: rgba(143, 160, 255, 0.08);
+  color: var(--home-text);
+  text-decoration: none;
+}
+
+.calendar-reminder-item:hover {
+  background: rgba(143, 160, 255, 0.14);
+}
+
+.calendar-reminder-item span {
+  font-weight: 800;
+}
+
+.calendar-reminder-item small {
+  color: var(--home-muted);
+}
+
 /* Expanded Calendar */
 
 .calendar-card.calendar-expanded {

--- a/app/static/css/resources.css
+++ b/app/static/css/resources.css
@@ -1,0 +1,150 @@
+.resource-page {
+  --resource-gap: 22px;
+}
+
+.resource-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: var(--resource-gap);
+  margin-top: 24px;
+}
+
+.resource-layout--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.resource-panel {
+  padding: 26px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.resource-section-heading {
+  margin-bottom: 20px;
+}
+
+.resource-section-heading h2 {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.help-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.help-card {
+  min-height: 230px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+}
+
+.help-card i {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-size: 1.35rem;
+}
+
+.help-card h3,
+.rule-item h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 20px;
+}
+
+.help-card p,
+.support-list p,
+.rule-item p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.help-card a {
+  margin-top: auto;
+  color: var(--primary);
+  font-weight: 800;
+}
+
+.help-card a:hover {
+  color: var(--primary-hover);
+}
+
+.resource-sidebar-panel {
+  align-self: start;
+}
+
+.support-list {
+  display: grid;
+  gap: 18px;
+}
+
+.support-list strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--text);
+  font-size: 16px;
+}
+
+.rules-list {
+  display: grid;
+  gap: 14px;
+}
+
+.rule-item {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+}
+
+.rule-item > span {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  background: var(--primary-soft);
+  color: var(--primary);
+  font-weight: 900;
+}
+
+.rule-item div {
+  display: grid;
+  gap: 8px;
+}
+
+@media (max-width: 980px) {
+  .resource-layout,
+  .help-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .resource-panel {
+    padding: 20px;
+  }
+
+  .rule-item {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/static/js/base.js
+++ b/app/static/js/base.js
@@ -10,6 +10,8 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const profileToggle = document.querySelector("#profileToggle");
   const profileMenu = document.querySelector("#profileMenu");
+  const notificationToggle = document.querySelector("#notificationToggle");
+  const notificationMenu = document.querySelector("#notificationMenu");
 
   if (!appShell) return;
 
@@ -61,9 +63,35 @@ document.addEventListener("DOMContentLoaded", function () {
   // -------------------------
   // Profile dropdown
   // -------------------------
+  function openNotificationMenu() {
+    if (!notificationToggle || !notificationMenu) return;
+
+    notificationMenu.hidden = false;
+    notificationToggle.setAttribute("aria-expanded", "true");
+  }
+
+  function closeNotificationMenu() {
+    if (!notificationToggle || !notificationMenu) return;
+
+    notificationMenu.hidden = true;
+    notificationToggle.setAttribute("aria-expanded", "false");
+  }
+
+  function toggleNotificationMenu() {
+    if (!notificationMenu) return;
+
+    if (notificationMenu.hidden) {
+      closeProfileMenu();
+      openNotificationMenu();
+    } else {
+      closeNotificationMenu();
+    }
+  }
+
   function openProfileMenu() {
     if (!profileToggle || !profileMenu) return;
 
+    closeNotificationMenu();
     profileMenu.hidden = false;
     profileToggle.setAttribute("aria-expanded", "true");
   }
@@ -96,6 +124,17 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  if (notificationToggle && notificationMenu) {
+    notificationToggle.addEventListener("click", function (event) {
+      event.stopPropagation();
+      toggleNotificationMenu();
+    });
+
+    notificationMenu.addEventListener("click", function (event) {
+      event.stopPropagation();
+    });
+  }
+
   // -------------------------
   // Close menus when clicking outside
   // -------------------------
@@ -103,9 +142,14 @@ document.addEventListener("DOMContentLoaded", function () {
     const clickedInsideSidebar = event.target.closest(".sidebar");
     const clickedSidebarToggle = event.target.closest("#sidebarToggle");
     const clickedProfile = event.target.closest(".profile-dropdown");
+    const clickedNotifications = event.target.closest(".notification-dropdown");
 
     if (!clickedProfile) {
       closeProfileMenu();
+    }
+
+    if (!clickedNotifications) {
+      closeNotificationMenu();
     }
 
     if (
@@ -123,6 +167,7 @@ document.addEventListener("DOMContentLoaded", function () {
   document.addEventListener("keydown", function (event) {
     if (event.key === "Escape") {
       closeProfileMenu();
+      closeNotificationMenu();
       closeMobileSidebar();
     }
   });

--- a/app/static/js/home.js
+++ b/app/static/js/home.js
@@ -27,45 +27,22 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const dayNames = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
-  const sessionDayMap = {
-    "Sun": "SUN",
-    "Sunday": "SUN",
-    "SUN": "SUN",
-
-    "Mon": "MON",
-    "Monday": "MON",
-    "MON": "MON",
-
-    "Tue": "TUE",
-    "Tuesday": "TUE",
-    "TUE": "TUE",
-
-    "Wed": "WED",
-    "Wednesday": "WED",
-    "WED": "WED",
-
-    "Thu": "THU",
-    "Thursday": "THU",
-    "THU": "THU",
-
-    "Fri": "FRI",
-    "Friday": "FRI",
-    "FRI": "FRI",
-
-    "Sat": "SAT",
-    "Saturday": "SAT",
-    "SAT": "SAT"
-  };
-
   let currentMonth =
     Number(window.CSHUB_CALENDAR_START_MONTH || new Date().getMonth() + 1) - 1;
 
   let currentYear =
     Number(window.CSHUB_CALENDAR_START_YEAR || new Date().getFullYear());
 
-  function getSessionsForDay(dayName) {
+  function formatDateKey(year, monthIndex, day) {
+    const month = String(monthIndex + 1).padStart(2, "0");
+    const date = String(day).padStart(2, "0");
+
+    return year + "-" + month + "-" + date;
+  }
+
+  function getSessionsForDate(dateKey) {
     return joinedSessions.filter(function (session) {
-      return sessionDayMap[session.day] === dayName;
+      return session.reminder_date === dateKey;
     });
   }
 
@@ -87,6 +64,46 @@ document.addEventListener("DOMContentLoaded", function () {
         return session.topic + " at " + session.time + mode + location;
       })
       .join(" | ");
+  }
+
+  function renderSelectedDateInfo(date, sessions) {
+    if (!selectedCalendarInfo) {
+      return;
+    }
+
+    selectedCalendarInfo.innerHTML = "";
+
+    const heading = document.createElement("strong");
+    heading.textContent = date;
+    selectedCalendarInfo.appendChild(heading);
+
+    if (!sessions || sessions.length === 0) {
+      const emptyText = document.createElement("p");
+      emptyText.textContent = "No joined Study Buddy session for this date.";
+      selectedCalendarInfo.appendChild(emptyText);
+      return;
+    }
+
+    const list = document.createElement("div");
+    list.className = "calendar-reminder-list";
+
+    sessions.forEach(function (session) {
+      const link = document.createElement("a");
+      link.href = "/sessions/" + session.id;
+      link.className = "calendar-reminder-item";
+
+      const title = document.createElement("span");
+      title.textContent = session.topic;
+
+      const meta = document.createElement("small");
+      meta.textContent = session.time + " - " + session.unit_code;
+
+      link.appendChild(title);
+      link.appendChild(meta);
+      list.appendChild(link);
+    });
+
+    selectedCalendarInfo.appendChild(list);
   }
 
   function renderCalendar() {
@@ -125,13 +142,13 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     for (let day = 1; day <= totalDays; day++) {
-      const dateObj = new Date(currentYear, currentMonth, day);
-      const dayName = dayNames[dateObj.getDay()];
-      const sessionsForDay = getSessionsForDay(dayName);
+      const dateKey = formatDateKey(currentYear, currentMonth, day);
+      const sessionsForDay = getSessionsForDate(dateKey);
 
       const dayButton = document.createElement("button");
       dayButton.type = "button";
       dayButton.textContent = day;
+      dayButton.dataset.dateKey = dateKey;
 
       dayButton.dataset.date =
         day + " " + monthNames[currentMonth] + " " + currentYear;
@@ -193,7 +210,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
 
         if (date && sessionText) {
-          selectedCalendarInfo.textContent = date + ": " + sessionText;
+          renderSelectedDateInfo(date, getSessionsForDate(day.dataset.dateKey));
         } else if (sessionText) {
           selectedCalendarInfo.textContent = sessionText;
         } else {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -185,12 +185,12 @@
 
           <p class="sidebar-section-title">Resources</p>
 
-          <a href="#" class="sidebar-link">
+          <a href="{{ url_for('main.help_page') }}" class="sidebar-link {% if request.path == url_for('main.help_page') %}is-active{% endif %}">
             <i class="bi bi-question-circle sidebar-icon" aria-hidden="true"></i>
             <span class="sidebar-label">Help</span>
           </a>
 
-          <a href="#" class="sidebar-link">
+          <a href="{{ url_for('main.rules') }}" class="sidebar-link {% if request.path == url_for('main.rules') %}is-active{% endif %}">
             <i class="bi bi-shield-check sidebar-icon" aria-hidden="true"></i>
             <span class="sidebar-label">CSHub Rules</span>
           </a>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -63,13 +63,55 @@
       </form>
 
       <div class="topbar-actions">
-        <button class="icon-button" type="button" aria-label="Live chat">
-          <i class="bi bi-chat-dots" aria-hidden="true"></i>
-        </button>
+        <div class="notification-dropdown">
+          <button
+            class="icon-button notification-button"
+            id="notificationToggle"
+            type="button"
+            aria-label="View session notifications"
+            aria-haspopup="true"
+            aria-expanded="false"
+          >
+            <i class="bi bi-bell" aria-hidden="true"></i>
 
-        <button class="icon-button" type="button" aria-label="Notifications">
-          <i class="bi bi-bell" aria-hidden="true"></i>
-        </button>
+            {% if session_notification_count %}
+              <span class="notification-badge">{{ session_notification_count if session_notification_count < 10 else '9+' }}</span>
+            {% endif %}
+          </button>
+
+          <div class="notification-menu" id="notificationMenu" hidden>
+            <div class="notification-menu-header">
+              <h2>Session Messages</h2>
+              <span>{{ session_notification_count }} new</span>
+            </div>
+
+            {% if session_notifications %}
+              <div class="notification-list">
+                {% for notification in session_notifications %}
+                  <a
+                    href="{{ url_for('main.session_detail', session_id=notification.session_id) }}"
+                    class="notification-item"
+                  >
+                    <span class="notification-avatar">
+                      {{ notification.user.username[0].upper() if notification.user and notification.user.username else 'S' }}
+                    </span>
+
+                    <span class="notification-copy">
+                      <strong>{{ notification.user.username if notification.user else 'Student' }}</strong>
+                      <span>{{ notification.session.topic if notification.session else 'Study session' }}</span>
+                      <small>{{ notification.content }}</small>
+                    </span>
+                  </a>
+                {% endfor %}
+              </div>
+            {% else %}
+              <div class="notification-empty">
+                <i class="bi bi-bell-slash" aria-hidden="true"></i>
+                <p>No new messages from your joined sessions.</p>
+              </div>
+            {% endif %}
+          </div>
+        </div>
 
         <div class="profile-dropdown">
           <button

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,7 +37,7 @@
     <!-- Top Navigation -->
     <header class="topbar">
       <div class="topbar-left">
-        <a href="/" class="brand-link">CSHub</a>
+        <a href="{{ url_for('main.home') }}" class="brand-link">CSHub</a>
 
         <button
           class="sidebar-toggle"
@@ -161,7 +161,7 @@
       <aside class="sidebar" id="appSidebar">
         <nav class="sidebar-nav" aria-label="Main navigation">
 
-          <a href="/" class="sidebar-link {% if request.path == '/' %}is-active{% endif %}">
+          <a href="{{ url_for('main.home') }}" class="sidebar-link {% if request.path == url_for('main.home') %}is-active{% endif %}">
             <i class="bi bi-house-door sidebar-icon" aria-hidden="true"></i>
             <span class="sidebar-label">Home</span>
           </a>

--- a/app/templates/help.html
+++ b/app/templates/help.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+
+{% block title %}Help - CSHub{% endblock %}
+
+{% block styles %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/studybuddy.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/resources.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="studybuddy-page resource-page">
+  <div class="hero hero--compact">
+    <div class="hero__content">
+      <p class="hero__eyebrow">Resources</p>
+      <h1 class="hero__title">Help</h1>
+      <p class="hero__subtitle">
+        Quick guidance for using CSHub's dashboard, announcements, Study Buddy sessions, and message notifications.
+      </p>
+    </div>
+  </div>
+
+  <div class="resource-layout">
+    <section class="resource-panel">
+      <div class="resource-section-heading">
+        <p class="hero__eyebrow">Getting Started</p>
+        <h2>Common tasks</h2>
+      </div>
+
+      <div class="help-grid">
+        <article class="help-card">
+          <i class="bi bi-house-door" aria-hidden="true"></i>
+          <h3>Use your Home dashboard</h3>
+          <p>After login, Home shows your joined sessions, saved sessions, recent activity, and quick links back into Study Buddy.</p>
+          <a href="{{ url_for('main.home') }}">Open Home</a>
+        </article>
+
+        <article class="help-card">
+          <i class="bi bi-newspaper" aria-hidden="true"></i>
+          <h3>Check announcements</h3>
+          <p>Announcements contain course reminders, club events, and platform updates. Select an announcement row to read the full details.</p>
+          <a href="{{ url_for('main.announcements') }}">View Announcements</a>
+        </article>
+
+        <article class="help-card">
+          <i class="bi bi-journal-code" aria-hidden="true"></i>
+          <h3>Find a Study Buddy</h3>
+          <p>Browse sessions by topic, unit, time, mode, and availability. Join sessions you plan to attend or save them for later.</p>
+          <a href="{{ url_for('main.studybuddy') }}">Browse Sessions</a>
+        </article>
+
+        <article class="help-card">
+          <i class="bi bi-bell" aria-hidden="true"></i>
+          <h3>Follow session messages</h3>
+          <p>The bell shows new messages from sessions you have joined. Opening a session marks its current messages as read.</p>
+          <a href="{{ url_for('main.my_sessions', view='joined') }}">My Sessions</a>
+        </article>
+      </div>
+    </section>
+
+    <aside class="resource-panel resource-sidebar-panel">
+      <div class="resource-section-heading">
+        <p class="hero__eyebrow">Support</p>
+        <h2>Need a hand?</h2>
+      </div>
+
+      <div class="support-list">
+        <div>
+          <strong>Account access</strong>
+          <p>Use your username or email to log in. Register with a unique username and a password containing letters and numbers.</p>
+        </div>
+
+        <div>
+          <strong>Study session issues</strong>
+          <p>If a session is full, save it and check again later. If details look wrong, leave the session and choose another suitable group.</p>
+        </div>
+
+        <div>
+          <strong>Announcements</strong>
+          <p>Only administrators can publish announcements, so treat them as official CSHub notices.</p>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -235,7 +235,7 @@
                 <div>
                   <h4>{{ session.topic }}</h4>
                   <p>
-                    {{ session.day }} · {{ session.time }}
+                    {{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} · {{ session.time }}
                     {% if session.mode %}
                       · {{ session.mode|replace('-', ' ')|title }}
                     {% endif %}
@@ -277,7 +277,7 @@
                 <div>
                   <h4>{{ session.topic }}</h4>
                   <p>
-                    {{ session.day }} · {{ session.time }}
+                    {{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} · {{ session.time }}
                     {% if session.mode %}
                       · {{ session.mode|replace('-', ' ')|title }}
                     {% endif %}

--- a/app/templates/my_sessions.html
+++ b/app/templates/my_sessions.html
@@ -71,7 +71,7 @@
               <div class="meta-grid">
                 <div class="meta-item"><strong>Host:</strong> {{ session.host_name }}</div>
                 <div class="meta-item"><strong>Mode:</strong> {{ session.mode|replace('-', ' ')|title }}</div>
-                <div class="meta-item"><strong>Time:</strong> {{ session.day }} {{ session.time }}</div>
+                <div class="meta-item"><strong>Time:</strong> {{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} {{ session.time }}</div>
                 <div class="meta-item"><strong>Location:</strong> {{ session.location or 'Online' }}</div>
                 <div class="meta-item"><strong>Joined:</strong> {{ session.joined_count }} / {{ session.capacity }}</div>
               </div>

--- a/app/templates/rules.html
+++ b/app/templates/rules.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block title %}CSHub Rules - CSHub{% endblock %}
+
+{% block styles %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/studybuddy.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/resources.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="studybuddy-page resource-page">
+  <div class="hero hero--compact">
+    <div class="hero__content">
+      <p class="hero__eyebrow">Resources</p>
+      <h1 class="hero__title">CSHub Rules</h1>
+      <p class="hero__subtitle">
+        Shared expectations for a useful, respectful, and reliable student learning space.
+      </p>
+    </div>
+  </div>
+
+  <div class="resource-layout resource-layout--single">
+    <section class="resource-panel">
+      <div class="resource-section-heading">
+        <p class="hero__eyebrow">Community Guidelines</p>
+        <h2>Use CSHub responsibly</h2>
+      </div>
+
+      <div class="rules-list">
+        <article class="rule-item">
+          <span>1</span>
+          <div>
+            <h3>Keep discussions respectful</h3>
+            <p>Ask questions clearly, reply constructively, and avoid personal attacks, harassment, or dismissive comments.</p>
+          </div>
+        </article>
+
+        <article class="rule-item">
+          <span>2</span>
+          <div>
+            <h3>Use Study Buddy for real study plans</h3>
+            <p>Create sessions with accurate unit codes, topics, times, locations, capacity, and mode so other students can plan confidently.</p>
+          </div>
+        </article>
+
+        <article class="rule-item">
+          <span>3</span>
+          <div>
+            <h3>Do not share private information</h3>
+            <p>Keep passwords, student IDs, private contact details, and sensitive course information out of public messages.</p>
+          </div>
+        </article>
+
+        <article class="rule-item">
+          <span>4</span>
+          <div>
+            <h3>Protect academic integrity</h3>
+            <p>Use sessions for revision, explanation, planning, and collaboration. Do not request or provide answers intended for submission.</p>
+          </div>
+        </article>
+
+        <article class="rule-item">
+          <span>5</span>
+          <div>
+            <h3>Keep announcements trustworthy</h3>
+            <p>Announcements are for official platform and course notices. Admin users should write clear summaries and complete details.</p>
+          </div>
+        </article>
+
+        <article class="rule-item">
+          <span>6</span>
+          <div>
+            <h3>Leave sessions you no longer need</h3>
+            <p>If you cannot attend or no longer need a group, leave it so another student can take the available place.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  </div>
+</div>
+{% endblock %}

--- a/app/templates/session_detail.html
+++ b/app/templates/session_detail.html
@@ -17,7 +17,7 @@
       <div class="room-meta">
         <span>{{ session.unit_code }}</span>
         <span>{{ session.mode|replace('-', ' ')|title }}</span>
-        <span>{{ session.day }} {{ session.time }}</span>
+        <span>{{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} {{ session.time }}</span>
         <span>{{ session.location or 'Online' }}</span>
         <span>{{ session.joined_count }} / {{ session.capacity }} joined</span>
       </div>
@@ -71,7 +71,7 @@
         <div class="info-list">
           <p><strong>Host:</strong> {{ session.host_name }}</p>
           <p><strong>Mode:</strong> {{ session.mode|replace('-', ' ')|title }}</p>
-          <p><strong>Time:</strong> {{ session.day }} {{ session.time }}</p>
+          <p><strong>Time:</strong> {{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} {{ session.time }}</p>
           <p><strong>Location:</strong> {{ session.location or 'Online' }}</p>
           <p><strong>Capacity:</strong> {{ session.capacity }}</p>
         </div>

--- a/app/templates/studybuddy.html
+++ b/app/templates/studybuddy.html
@@ -70,7 +70,7 @@
               <div class="meta-grid">
                 <div class="meta-item"><strong>Host:</strong> {{ session.host_name }}</div>
                 <div class="meta-item"><strong>Mode:</strong> {{ session.mode|replace('-', ' ')|title }}</div>
-                <div class="meta-item"><strong>Time:</strong> {{ session.day }} {{ session.time }}</div>
+                <div class="meta-item"><strong>Time:</strong> {{ session.session_date.strftime('%d %b %Y') if session.session_date else session.day }} {{ session.time }}</div>
                 <div class="meta-item"><strong>Location:</strong> {{ session.location or 'Online' }}</div>
                 <div class="meta-item"><strong>Joined:</strong> {{ session.joined_count }} / {{ session.capacity }}</div>
               </div>
@@ -180,17 +180,8 @@
 
     <div class="two-col">
       <div class="field">
-        <label for="day">Day</label>
-        <select id="day" name="day" required>
-          <option value="">Select day</option>
-          <option value="Mon">Monday</option>
-          <option value="Tue">Tuesday</option>
-          <option value="Wed">Wednesday</option>
-          <option value="Thu">Thursday</option>
-          <option value="Fri">Friday</option>
-          <option value="Sat">Saturday</option>
-          <option value="Sun">Sunday</option>
-        </select>
+        <label for="session_date">Date</label>
+        <input id="session_date" name="session_date" type="date" required>
       </div>
 
       <div class="field">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import sys
 import tempfile
 import threading
 from contextlib import closing
+from datetime import date, timedelta
 from pathlib import Path
 
 import pytest
@@ -75,12 +76,15 @@ def seed_database():
     db.session.add_all([student, host])
     db.session.commit()
 
+    session_date = date.today() + timedelta(days=3)
+
     session = StudySession(
         unit_code="CITS5505",
         topic="Seeded Study Session",
         description="A seeded study session for tests.",
         host_name=host.full_name,
-        day="Fri",
+        session_date=session_date,
+        day=session_date.strftime("%a"),
         time="4:00 PM",
         mode="online",
         location=None,

--- a/tests/test_selenium.py
+++ b/tests/test_selenium.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import date, timedelta
 
 pytest.importorskip("selenium")
 
@@ -18,8 +19,8 @@ def test_user_can_register_and_login(browser, live_server):
     register_user(browser, live_server, "seleniumuser", "selenium@example.com")
     login_user(browser, live_server, "seleniumuser")
 
-    assert "Study Buddy" in browser.page_source
-    assert "/studybuddy" in browser.current_url
+    assert "Welcome back" in browser.page_source
+    assert "/home" in browser.current_url
 
 
 def test_user_can_create_study_session(browser, live_server):
@@ -31,7 +32,7 @@ def test_user_can_create_study_session(browser, live_server):
     browser.find_element(By.ID, "description").send_keys("Created from a Selenium test.")
     browser.find_element(By.ID, "host_name").send_keys("Study Student")
     browser.find_element(By.ID, "capacity").send_keys("4")
-    Select(browser.find_element(By.ID, "day")).select_by_value("Mon")
+    browser.find_element(By.ID, "session_date").send_keys((date.today() + timedelta(days=7)).isoformat())
     browser.find_element(By.ID, "time").send_keys("10:00 AM")
     Select(browser.find_element(By.ID, "mode")).select_by_value("online")
     browser.find_element(By.CSS_SELECTOR, ".session-form button[type='submit']").click()
@@ -95,5 +96,6 @@ def login_user(browser, live_server, identifier="student", password="Password1")
     browser.find_element(By.ID, "login-identifier").send_keys(identifier)
     browser.find_element(By.ID, "login-password").send_keys(password)
     browser.find_element(By.CSS_SELECTOR, ".auth-submit").click()
-    wait.until(EC.url_contains("/studybuddy"))
+    wait.until(EC.url_contains("/home"))
+    browser.get(f"{live_server}/studybuddy")
     wait.until(EC.presence_of_element_located((By.ID, "openCreateModal")))

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -44,7 +44,7 @@ def test_login_and_logout_flow(client):
     )
 
     assert response.status_code == 200
-    assert b"Study Buddy" in response.data
+    assert b"Welcome back" in response.data
 
     response = client.post("/logout", follow_redirects=True)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -59,6 +59,28 @@ def test_studybuddy_requires_login(client):
     assert "/login" in response.headers["Location"]
 
 
+def test_resource_pages_require_login(client):
+    for path in ("/help", "/rules"):
+        response = client.get(path)
+
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+
+def test_resource_pages_render_for_logged_in_user(auth_client):
+    response = auth_client.get("/help")
+
+    assert response.status_code == 200
+    assert b"Common tasks" in response.data
+    assert b"Study Buddy" in response.data
+
+    response = auth_client.get("/rules")
+
+    assert response.status_code == 200
+    assert b"CSHub Rules" in response.data
+    assert b"academic integrity" in response.data
+
+
 def test_create_session_persists_and_auto_joins_host(auth_client, app):
     response = auth_client.post(
         "/studybuddy/create",

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,5 @@
 from app import db
-from app.models import SessionMessage, StudySession, User
+from app.models import SessionMessage, SessionReadState, StudySession, User
 
 
 def test_register_creates_user_with_hashed_password(client, app):
@@ -128,3 +128,63 @@ def test_messages_and_replies_are_persisted(auth_client, app):
         reply = SessionMessage.query.filter_by(content="Start with the project rubric.").one()
         assert reply.parent_id == message_id
         assert reply.session_id == session_id
+
+
+def test_session_notifications_clear_after_viewing_session(auth_client, app):
+    with app.app_context():
+        session = StudySession.query.filter_by(topic="Seeded Study Session").one()
+        student = User.query.filter_by(username="student").one()
+        session_id = session.id
+        student_id = student.id
+
+    auth_client.post(f"/sessions/{session_id}/join")
+
+    with app.app_context():
+        host = User.query.filter_by(username="host").one()
+        message = SessionMessage(
+            session_id=session_id,
+            user_id=host.id,
+            content="Please check the shared notes.",
+        )
+        db.session.add(message)
+        db.session.commit()
+
+    response = auth_client.get("/home")
+    assert b"1 new" in response.data
+    assert b"notification-badge" in response.data
+    assert b"Please check the shared notes." in response.data
+
+    auth_client.get(f"/sessions/{session_id}")
+
+    with app.app_context():
+        read_state = SessionReadState.query.filter_by(
+            user_id=student_id,
+            session_id=session_id,
+        ).one()
+        first_read_message_id = read_state.last_read_message_id
+
+    response = auth_client.get("/home")
+    assert b"0 new" in response.data
+    assert b"notification-badge" not in response.data
+
+    with app.app_context():
+        host = User.query.filter_by(username="host").one()
+        message = SessionMessage(
+            session_id=session_id,
+            user_id=host.id,
+            content="I added one more example.",
+        )
+        db.session.add(message)
+        db.session.commit()
+
+    response = auth_client.get("/home")
+    assert b"1 new" in response.data
+    assert b"notification-badge" in response.data
+    assert b"I added one more example." in response.data
+
+    with app.app_context():
+        read_state = SessionReadState.query.filter_by(
+            user_id=student_id,
+            session_id=session_id,
+        ).one()
+        assert read_state.last_read_message_id == first_read_message_id

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,3 +1,6 @@
+import json
+import re
+
 from app import db
 from app.models import SessionMessage, SessionReadState, StudySession, User
 
@@ -89,7 +92,7 @@ def test_create_session_persists_and_auto_joins_host(auth_client, app):
             "topic": "Unit Test Session",
             "description": "Created during a unit test.",
             "host_name": "Study Student",
-            "day": "Mon",
+            "session_date": "2026-05-18",
             "time": "10:00 AM",
             "mode": "hybrid",
             "location": "EZONE North 1.24",
@@ -102,6 +105,8 @@ def test_create_session_persists_and_auto_joins_host(auth_client, app):
         session = StudySession.query.filter_by(topic="Unit Test Session").one()
         user = User.query.filter_by(username="student").one()
         assert session.unit_code == "CITS5505"
+        assert session.session_date.isoformat() == "2026-05-18"
+        assert session.day == "Mon"
         assert session.location == "EZONE North 1.24"
         assert session.host_id == user.id
         assert session in user.joined
@@ -128,6 +133,35 @@ def test_join_leave_save_and_unsave_session(auth_client, app):
         session = db.session.get(StudySession, session_id)
         assert session not in user.joined
         assert session not in user.saved
+
+
+def test_joined_session_is_available_as_calendar_reminder(auth_client, app):
+    with app.app_context():
+        session = StudySession.query.filter_by(topic="Seeded Study Session").one()
+        session_id = session.id
+        expected_reminder_date = session.session_date.isoformat()
+
+    auth_client.post(f"/sessions/{session_id}/join")
+    response = auth_client.get("/home")
+
+    match = re.search(
+        rb'<script id="joinedSessionsData" type="application/json">\s*(.*?)\s*</script>',
+        response.data,
+        re.S,
+    )
+
+    assert match is not None
+
+    joined_sessions_data = json.loads(match.group(1))
+    reminder = next(
+        session_data
+        for session_data in joined_sessions_data
+        if session_data["id"] == session_id
+    )
+
+    assert reminder["topic"] == "Seeded Study Session"
+    assert reminder["time"] == "4:00 PM"
+    assert reminder["reminder_date"] == expected_reminder_date
 
 
 def test_messages_and_replies_are_persisted(auth_client, app):


### PR DESCRIPTION
## Summary

This PR collects the dashboard and session workflow improvements completed on May 12, 2026:

- add topbar notifications for messages in joined Study Buddy sessions
- track read state so notification badges clear after messages are viewed
- redirect users to the Home dashboard after login
- connect the Home entry points and add dedicated Help / CSHub Rules pages
- add concrete Study Buddy session dates and surface joined sessions as Home calendar reminders

## Details

### Navigation and dashboard flow
- Login now lands on `/home`
- The brand link and Home sidebar item route to the Home dashboard
- Resource navigation now includes working Help and CSHub Rules pages

### Session notifications
- The topbar bell shows messages from joined sessions posted by other users
- Notification state is persisted per user/session
- Viewing a session marks current messages as read

### Calendar reminders
- Study Buddy session creation now stores a concrete `session_date`
- Home calendar reminders use the actual session date instead of weekday inference
- Calendar entries link back to the corresponding session detail page



## Issues

Closes #33

Partially addresses #32 by wiring Home/dashboard navigation, Study Buddy, Announcements/News-style navigation, and Help. The Forum sidebar item is still a placeholder, so #32 should remain open until that route is implemented.
