### PR TITLE
Fix profile route and user initials

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -547,3 +547,15 @@ def reply_message(session_id, message_id):
         db.session.commit()
 
     return redirect(url_for("main.session_detail", session_id=session_id))
+
+
+# ---------- Messages ----------
+@main.route("/profile")
+@login_required
+def profile():
+    current_user = get_current_user()
+
+    return render_template(
+        "profile.html",
+        current_user=current_user
+    )

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -80,11 +80,11 @@
             aria-haspopup="true"
             aria-expanded="false"
           >
-            <span class="profile-avatar">H</span>
+            <span class="profile-avatar">{{ current_user.username[:1]|upper }}</span>
           </button>
 
           <div class="profile-menu" id="profileMenu" hidden>
-            <a href="/profile" class="profile-menu-item">
+            <a href="{{ url_for('main.profile') }}" class="profile-menu-item">
               <i class="bi bi-person-circle" aria-hidden="true"></i>
               <span>View Profile</span>
             </a>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -13,7 +13,9 @@
   <header class="profile-header">
     <div class="profile-identity">
       <div class="profile-avatar-wrap">
-        <div class="profile-avatar-large">H</div>
+        <div class="profile-avatar-large">
+          {{ current_user.username[:1]|upper }}
+        </div>
 
         <button class="avatar-edit-button" type="button" aria-label="Edit profile picture">
           📷
@@ -21,8 +23,8 @@
       </div>
 
       <div class="profile-heading">
-        <h1 class="profile-name">Hans Lionar</h1>
-        <p class="profile-username">@hanslionar</p>
+        <h1 class="profile-name">{{ current_user.username }}</h1>
+        <p class="profile-username">@{{ current_user.username }}</p>
       </div>
     </div>
   </header>
@@ -136,8 +138,8 @@
         <div class="profile-card-body">
           <h2 class="profile-card-title">Profile</h2>
 
-          <h3 class="profile-side-name">Hans Lionar</h3>
-          <p class="profile-side-meta">@hanslionar</p>
+          <h3 class="profile-side-name">{{ current_user.username }}</h3>
+          <p class="profile-side-meta">@{{ current_user.username }}</p>
 
           <button class="profile-share-button" type="button">
             Share


### PR DESCRIPTION
## Summary

This PR fixes the missing `/profile` route that caused the Profile menu link to return a 404 error.

Changes included:
- Added a `/profile` route in `app/routes.py`
- Connected the profile dropdown link in `base.html` using `url_for('main.profile')`
- Added/connected `profile.html` to extend `base.html`
- Updated user initials rendering using `[:1]|upper` so the avatar displays correctly

Closes #38

## Tested

Log in using a valid account.
Click the profile avatar/menu in the top-right navigation.
Click View Profile.

Confirm that:
The app redirects to /profile
The profile page loads successfully
No 404 error appears
The user initial displays correctly in the avatar