### PR TITLE
Add forum models and database migration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,12 @@
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 from sqlalchemy import inspect, text
 from config import Config
 
+
 db = SQLAlchemy()
+migrate = Migrate()
 
 
 def create_app():
@@ -11,19 +14,38 @@ def create_app():
     app.config.from_object(Config)
 
     db.init_app(app)
+    migrate.init_app(app, db, render_as_batch=True)
+
+    # Import models so Flask-Migrate/Alembic can detect model changes.
+    from app import models  # noqa: F401
 
     from app.routes import main
     app.register_blueprint(main)
 
-    if app.config.get("AUTO_CREATE_DATABASE", True):
+    # Legacy fallback only.
+    # For team development, prefer:
+    #   flask db upgrade
+    #   python scripts/seed_dev_db.py
+    #
+    # This should normally be False when using migrations.
+    if app.config.get("AUTO_CREATE_DATABASE", False):
         create_database_schema(app)
-        if app.config.get("AUTO_SEED_DEMO_DATA", True):
+
+        if app.config.get("AUTO_SEED_DEMO_DATA", False):
             seed_empty_database(app)
 
     return app
 
 
 def create_database_schema(app):
+    """
+    Legacy helper for creating tables without migrations.
+
+    Prefer Flask-Migrate instead:
+        flask db upgrade
+
+    This function is kept only as a fallback for local development.
+    """
     with app.app_context():
         from app import models  # noqa: F401
 
@@ -32,22 +54,42 @@ def create_database_schema(app):
 
 
 def ensure_study_session_columns():
+    """
+    Legacy helper for old local databases.
+
+    These manual ALTER TABLE statements should eventually be replaced
+    by proper migration files.
+    """
     inspector = inspect(db.engine)
+
     if "study_session" not in inspector.get_table_names():
         return
 
-    columns = {column["name"] for column in inspector.get_columns("study_session")}
+    columns = {
+        column["name"]
+        for column in inspector.get_columns("study_session")
+    }
 
     if "location" not in columns:
-        db.session.execute(text("ALTER TABLE study_session ADD COLUMN location VARCHAR(150)"))
+        db.session.execute(
+            text("ALTER TABLE study_session ADD COLUMN location VARCHAR(150)")
+        )
         db.session.commit()
 
     if "session_date" not in columns:
-        db.session.execute(text("ALTER TABLE study_session ADD COLUMN session_date DATE"))
+        db.session.execute(
+            text("ALTER TABLE study_session ADD COLUMN session_date DATE")
+        )
         db.session.commit()
 
 
 def seed_empty_database(app):
+    """
+    Legacy helper for auto-seeding an empty database.
+
+    Prefer running this manually:
+        python scripts/seed_dev_db.py
+    """
     with app.app_context():
         from app.seed import seed_demo_data
 

--- a/config.py
+++ b/config.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 import os
 
+
 BASE_DIR = Path(__file__).resolve().parent
 INSTANCE_DIR = BASE_DIR / "instance"
 INSTANCE_DIR.mkdir(exist_ok=True)
+
+DB_PATH = INSTANCE_DIR / "studyhub.db"
 
 
 class Config:
@@ -14,9 +17,15 @@ class Config:
 
     SQLALCHEMY_DATABASE_URI = os.environ.get(
         "DATABASE_URL",
-        f"sqlite:///{INSTANCE_DIR / 'studyhub.db'}"
+        f"sqlite:///{DB_PATH.as_posix()}"
     )
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    AUTO_CREATE_DATABASE = os.environ.get("AUTO_CREATE_DATABASE", "1") == "1"
-    AUTO_SEED_DEMO_DATA = os.environ.get("AUTO_SEED_DEMO_DATA", "1") == "1"
+
+    # Prefer Flask-Migrate for team development:
+    #   flask --app app:create_app db upgrade
+    #   python scripts/seed_dev_db.py
+    #
+    # These legacy options should normally stay disabled.
+    AUTO_CREATE_DATABASE = os.environ.get("AUTO_CREATE_DATABASE", "0") == "1"
+    AUTO_SEED_DEMO_DATA = os.environ.get("AUTO_SEED_DEMO_DATA", "0") == "1"

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Single-database configuration for Flask.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,113 @@
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+
+def get_engine():
+    try:
+        # this works with Flask-SQLAlchemy<3 and Alchemical
+        return current_app.extensions['migrate'].db.get_engine()
+    except (TypeError, AttributeError):
+        # this works with Flask-SQLAlchemy>=3
+        return current_app.extensions['migrate'].db.engine
+
+
+def get_engine_url():
+    try:
+        return get_engine().url.render_as_string(hide_password=False).replace(
+            '%', '%%')
+    except AttributeError:
+        return str(get_engine().url).replace('%', '%%')
+
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option('sqlalchemy.url', get_engine_url())
+target_db = current_app.extensions['migrate'].db
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_metadata():
+    if hasattr(target_db, 'metadatas'):
+        return target_db.metadatas[None]
+    return target_db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=get_metadata(), literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    conf_args = current_app.extensions['migrate'].configure_args
+    if conf_args.get("process_revision_directives") is None:
+        conf_args["process_revision_directives"] = process_revision_directives
+
+    connectable = get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=get_metadata(),
+            **conf_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 blinker==1.9.0
 click==8.3.0
 Flask==3.1.3
+Flask-Migrate==4.1.0
 Flask-SQLAlchemy==3.1.1
 greenlet==3.2.4
 itsdangerous==2.2.0


### PR DESCRIPTION
## Summary

This PR adds the forum database models and sets up Flask-Migrate for database schema changes.

## Changes

- Added Flask-Migrate setup in `app/__init__.py`
- Disabled automatic `db.create_all()` and auto-seeding by default
- Added database migration files
- Added forum-related models/tables
- Updated development seed flow for forum demo data

## How to test

After pulling this branch, run:

```bash
flask db upgrade
python scripts/seed_dev_db.py
python run.py