### PR TITLE
Add README and connect profile tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,156 @@
+# CSHub
+
+CSHub is a Flask-based web application designed for UWA Computer Science and Software Engineering students to communicate, share information, and organise study activities in one place. The application combines a community forum, announcements, Study Buddy sessions, user profiles, notifications, search, and saved content so that students can find useful information and interact with other users.
+
+The purpose of CSHub is to support peer learning and student collaboration. Instead of separating questions, study planning, announcements, and saved resources across different tools, CSHub provides a single student-focused hub where users can ask questions, reply to discussions, join study sessions, and view activity from other students.
+
+## Design and Use
+
+CSHub is designed to be:
+
+- **Engaging:** the interface uses a clean layout, dark visual style, clear cards, icons, and focused navigation to make important actions easy to notice.
+- **Effective:** the application gives students practical value by supporting discussion, peer help, search, study-session organisation, announcements, notifications, and saved resources.
+- **Intuitive:** common actions such as creating posts, replying to threads, searching, joining sessions, saving content, and viewing profiles are available through clear navigation and consistent UI patterns.
+
+Users can register and log in, create forum posts, comment on discussions, like and save forum threads, search for content, join or save Study Buddy sessions, receive session message notifications, and view profile activity. User data is persisted between sessions using a SQLite database managed through SQLAlchemy and Flask-Migrate.
+
+## Features
+
+- User registration, login, and logout
+- Passwords stored securely using hashed passwords
+- CSRF protection on forms
+- Forum threads and replies
+- Thread likes and saved forum posts
+- Study Buddy sessions
+- Join and save study sessions
+- Session message notifications
+- User profile page with activity statistics
+- Announcements and resource pages
+- Search functionality
+- SQLite database managed through SQLAlchemy and Flask-Migrate
+- Unit and Selenium tests
+
+## Technology Stack
+
+- Python
+- Flask
+- Flask-SQLAlchemy
+- Flask-Migrate
+- Flask-WTF
+- SQLite
+- HTML
+- CSS
+- JavaScript
+- Bootstrap Icons
+- Pytest
+- Selenium
+
+## Group Members
+
+| UWA ID | Name | GitHub Username |
+|---|---|---|
+| 24570238 | Qiumei Wang | merylwang86 |
+| 24700839 | Varshitha Raparla | raparlavarshitha-glitch |
+| 24661999 | Hans Lionar | hplionar |
+
+## Project Structure
+
+```text
+CITS5505/
+├── app/
+│   ├── auth/
+│   ├── main/
+│   ├── models/
+│   ├── static/
+│   ├── templates/
+│   └── __init__.py
+├── migrations/
+├── scripts/
+├── tests/
+├── config.py
+├── requirements.txt
+├── run.py
+├── run_project.md
+└── README.md
+```
+
+
+## Running the Application Locally
+
+These instructions assume you are running the commands from the project root directory.
+
+### 1. Create and activate a virtual environment
+
+On Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+On macOS/Linux:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 2. Install dependencies
+
+```powershell
+python -m pip install -r requirements.txt
+```
+
+### 3. Apply database migrations
+
+```powershell
+python -m flask --app app:create_app db upgrade
+```
+
+If multiple migration heads are present, run:
+
+```powershell
+python -m flask --app app:create_app db upgrade heads
+```
+
+### 4. Seed development data
+
+```powershell
+python scripts/seed_dev_db.py
+```
+
+### 5. Run the application
+
+```powershell
+python run.py
+```
+
+Then open the application in your browser:
+
+```text
+http://127.0.0.1:5000
+```
+
+To stop the server, press `Ctrl + C` in the terminal.
+
+## Running Tests
+
+Run the full test suite:
+
+```powershell
+python -m pytest -q
+```
+
+Run only the unit tests:
+
+```powershell
+python -m pytest tests/test_unit.py -q
+```
+
+Run only the Selenium tests:
+
+```powershell
+python -m pytest tests/test_selenium.py -q
+```
+
+The Selenium tests require Google Chrome and Selenium WebDriver support. These tests use a live Flask server fixture to test the application through the browser.

--- a/app/routes.py
+++ b/app/routes.py
@@ -1156,22 +1156,222 @@ def reply_message(session_id, message_id):
     return redirect(url_for("main.session_detail", session_id=session_id))
 
 
-# ---------- Messages ----------
+# ---------- Profile ----------
 @main.route("/profile")
 @login_required
 def profile():
     current_user = get_current_user()
 
-    post_count = ForumThread.query.filter_by(author_id=current_user.id).count()
-    comment_count = ForumReply.query.filter_by(author_id=current_user.id).count()
-    hosted_count = StudySession.query.filter_by(host_id=current_user.id).count()
-    joined_count = len(current_user.joined)
+    # Main profile tab
+    active_tab = request.args.get("tab", "overview")
+    valid_tabs = {"overview", "posts", "comments", "saved", "studybuddy"}
+
+    if active_tab not in valid_tabs:
+        active_tab = "overview"
+
+    # Saved tab filter
+    saved_filter = request.args.get("saved", "all")
+    valid_saved_filters = {"all", "posts", "sessions"}
+
+    if saved_filter not in valid_saved_filters:
+        saved_filter = "all"
+
+    # Study Buddy tab filter
+    studybuddy_filter = request.args.get("studybuddy", "all")
+    valid_studybuddy_filters = {"all", "hosted", "joined"}
+
+    if studybuddy_filter not in valid_studybuddy_filters:
+        studybuddy_filter = "all"
+
+    # Forum activity created by the current user
+    user_posts = (
+        ForumThread.query
+        .filter_by(author_id=current_user.id)
+        .order_by(ForumThread.created_at.desc(), ForumThread.id.desc())
+        .all()
+    )
+
+    user_comments = (
+        ForumReply.query
+        .filter_by(author_id=current_user.id)
+        .order_by(ForumReply.created_at.desc(), ForumReply.id.desc())
+        .all()
+    )
+
+    # Study Buddy sessions hosted by the current user
+    hosted_sessions = (
+        StudySession.query
+        .filter_by(host_id=current_user.id)
+        .order_by(StudySession.session_date.desc(), StudySession.id.desc())
+        .all()
+    )
+
+    # Joined sessions, excluding sessions the user already hosted
+    hosted_session_ids = {study_session.id for study_session in hosted_sessions}
+
+    joined_sessions = [
+        study_session
+        for study_session in current_user.joined
+        if study_session.id not in hosted_session_ids
+    ]
+
+    joined_sessions = sorted(
+        joined_sessions,
+        key=lambda study_session: (
+            study_session.session_date or date.min,
+            study_session.id,
+        ),
+        reverse=True,
+    )
+
+    # Saved forum posts and saved Study Buddy sessions
+    saved_forum_threads = sorted(
+        current_user.saved_forum_threads,
+        key=lambda thread: (
+            thread.created_at or datetime.min,
+            thread.id,
+        ),
+        reverse=True,
+    )
+
+    saved_sessions = sorted(
+        current_user.saved,
+        key=lambda study_session: (
+            study_session.session_date or date.min,
+            study_session.id,
+        ),
+        reverse=True,
+    )
+
+    # Saved tab items based on filter: all, posts, or sessions
+    saved_items = []
+
+    if saved_filter in {"all", "posts"}:
+        for thread in saved_forum_threads:
+            saved_items.append({
+                "kind": "post",
+                "thread": thread,
+                "sort_date": thread.created_at or datetime.min,
+            })
+
+    if saved_filter in {"all", "sessions"}:
+        for study_session in saved_sessions:
+            session_datetime = (
+                datetime.combine(study_session.session_date, datetime.min.time())
+                if study_session.session_date
+                else datetime.min
+            )
+
+            saved_items.append({
+                "kind": "session",
+                "session": study_session,
+                "sort_date": session_datetime,
+            })
+
+    saved_items.sort(
+        key=lambda item: item["sort_date"],
+        reverse=True,
+    )
+
+    # Study Buddy tab items based on filter: all, hosted, or joined
+    studybuddy_items = []
+
+    if studybuddy_filter in {"all", "hosted"}:
+        for study_session in hosted_sessions:
+            studybuddy_items.append({
+                "role": "Hosted",
+                "initial": "H",
+                "session": study_session,
+            })
+
+    if studybuddy_filter in {"all", "joined"}:
+        for study_session in joined_sessions:
+            studybuddy_items.append({
+                "role": "Joined",
+                "initial": "J",
+                "session": study_session,
+            })
+
+    studybuddy_items.sort(
+        key=lambda item: (
+            item["session"].session_date or date.min,
+            item["session"].id,
+        ),
+        reverse=True,
+    )
+
+    # Overview tab: recent mixed activity
+    recent_activity = []
+
+    for thread in user_posts[:3]:
+        recent_activity.append({
+            "type": "Forum",
+            "title": thread.title,
+            "meta": f"{thread.like_count} likes · {thread.reply_count} comments",
+            "url": url_for("main.thread_detail", thread_id=thread.id),
+            "created_at": thread.created_at or datetime.min,
+            "initial": "F",
+        })
+
+    for reply in user_comments[:3]:
+        reply_preview = reply.body[:120]
+
+        if len(reply.body) > 120:
+            reply_preview += "..."
+
+        recent_activity.append({
+            "type": "Comment",
+            "title": reply.thread.title if reply.thread else "Forum comment",
+            "meta": reply_preview,
+            "url": url_for("main.thread_detail", thread_id=reply.thread_id),
+            "created_at": reply.created_at or datetime.min,
+            "initial": "C",
+        })
+
+    for study_session in hosted_sessions[:3]:
+        session_datetime = (
+            datetime.combine(study_session.session_date, datetime.min.time())
+            if study_session.session_date
+            else datetime.min
+        )
+
+        session_date_label = (
+            study_session.session_date.strftime("%d %b %Y")
+            if study_session.session_date
+            else "Date TBA"
+        )
+
+        recent_activity.append({
+            "type": "Study Buddy",
+            "title": study_session.topic,
+            "meta": f"{study_session.unit_code} · {session_date_label}",
+            "url": url_for("main.session_detail", session_id=study_session.id),
+            "created_at": session_datetime,
+            "initial": "S",
+        })
+
+    recent_activity.sort(
+        key=lambda item: item["created_at"],
+        reverse=True,
+    )
 
     return render_template(
         "profile.html",
         current_user=current_user,
-        post_count=post_count,
-        comment_count=comment_count,
-        hosted_count=hosted_count,
-        joined_count=joined_count,
+        active_tab=active_tab,
+        saved_filter=saved_filter,
+        studybuddy_filter=studybuddy_filter,
+        user_posts=user_posts,
+        user_comments=user_comments,
+        hosted_sessions=hosted_sessions,
+        joined_sessions=joined_sessions,
+        saved_forum_threads=saved_forum_threads,
+        saved_sessions=saved_sessions,
+        saved_items=saved_items,
+        studybuddy_items=studybuddy_items,
+        recent_activity=recent_activity[:6],
+        post_count=len(user_posts),
+        comment_count=len(user_comments),
+        hosted_count=len(hosted_sessions),
+        joined_count=len(joined_sessions),
     )

--- a/app/routes.py
+++ b/app/routes.py
@@ -910,7 +910,16 @@ def reply_message(session_id, message_id):
 def profile():
     current_user = get_current_user()
 
+    post_count = ForumThread.query.filter_by(author_id=current_user.id).count()
+    comment_count = ForumReply.query.filter_by(author_id=current_user.id).count()
+    hosted_count = StudySession.query.filter_by(host_id=current_user.id).count()
+    joined_count = len(current_user.joined)
+
     return render_template(
         "profile.html",
-        current_user=current_user
+        current_user=current_user,
+        post_count=post_count,
+        comment_count=comment_count,
+        hosted_count=hosted_count,
+        joined_count=joined_count,
     )

--- a/app/static/css/profile.css
+++ b/app/static/css/profile.css
@@ -1,30 +1,31 @@
-/* =========================
+/* =========================================================
    PROFILE PAGE
-========================= */
+   Main wrapper for the profile screen.
+   ========================================================= */
 
 .profile-page {
   width: 100%;
   max-width: 1360px;
   margin: 0 auto;
   color: var(--text-main, #f5f7fb);
-  font-family: "Reddit Sans", system-ui, sans-serif;
+  font-family: "Reddit Sans", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 
-/* =========================
+/* =========================================================
    PROFILE HEADER
-========================= */
+   User avatar, display name, username, and bio.
+   ========================================================= */
 
 .profile-header {
-  width: 75%;
-  min-height: 100px;
-  padding: 10px 0 10px;
+  padding: 10px 0 8px;
 }
 
 .profile-identity {
   display: flex;
   align-items: center;
   gap: 18px;
+  min-width: 0;
 }
 
 .profile-avatar-wrap {
@@ -60,6 +61,14 @@
   cursor: pointer;
 }
 
+.avatar-edit-button:hover {
+  background: #3a4149;
+}
+
+.profile-heading {
+  min-width: 0;
+}
+
 .profile-name {
   margin: 0;
   font-family: "Space Grotesk", "Reddit Sans", system-ui, sans-serif;
@@ -74,21 +83,35 @@
   font-size: 0.95rem;
 }
 
+.profile-bio {
+  max-width: 46rem;
+  margin: 10px 0 0;
+  color: var(--text-soft, #cbd4df);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
 
-/* =========================
-   PROFILE TABS
-========================= */
+
+/* =========================================================
+   PROFILE NAVIGATION
+   Main tabs and settings shortcut.
+   ========================================================= */
 
 .profile-tabs {
   display: flex;
   align-items: center;
-  gap: 18px;
-  width: 70%;
-  padding: 24px 0 24px;
+  gap: 12px;
+  width: 100%;
+  padding: 24px 0;
   overflow-x: auto;
 }
 
-.profile-tab {
+.profile-tab,
+.profile-settings-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   border-radius: 999px;
   padding: 9px 18px;
   color: var(--text-soft, #cbd4df);
@@ -98,7 +121,8 @@
   white-space: nowrap;
 }
 
-.profile-tab:hover {
+.profile-tab:hover,
+.profile-settings-link:hover {
   background: rgba(137, 158, 181, 0.12);
   color: #ffffff;
 }
@@ -109,15 +133,26 @@
   color: #ffffff;
 }
 
+.profile-settings-link {
+  margin-left: auto;
+  border: 1px solid rgba(137, 158, 181, 0.22);
+  background: rgba(17, 19, 21, 0.65);
+}
 
-/* =========================
-   MAIN LAYOUT
-========================= */
+.profile-settings-link:hover {
+  border-color: rgba(137, 158, 181, 0.42);
+}
+
+
+/* =========================================================
+   PAGE LAYOUT
+   Main activity column and right profile sidebar.
+   ========================================================= */
 
 .profile-layout {
   display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
-  gap: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+  gap: 32px;
   align-items: start;
 }
 
@@ -128,143 +163,195 @@
 .profile-sidebar {
   display: grid;
   gap: 18px;
-
-  /* Lifts the right sidebar closer to the profile header */
-  margin-top: -200px;
-}
-
-
-/* =========================
-   CREATE POST ROW
-========================= */
-
-.profile-create-row {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  padding: 4px 0 22px;
-  border-bottom: 1px solid var(--border-soft, rgba(137, 158, 181, 0.22));
-}
-
-.create-post-button {
-  min-height: 38px;
-  padding: 0 18px;
-  border: 1px solid rgba(220, 228, 240, 0.55);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text-main, #f5f7fb);
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.9rem;
-  font-weight: 800;
-  text-decoration: none;
-}
-
-.create-post-button span {
-  font-size: 1.25rem;
-  line-height: 1;
-}
-
-.create-post-button:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.compact-icon-button {
-  width: 38px;
-  height: 38px;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text-muted, #9ba8b6);
-  font-size: 1.05rem;
-  cursor: pointer;
-}
-
-.compact-icon-button:hover {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text-main, #f5f7fb);
-}
-
-
-/* =========================
-   THREAD LIST
-========================= */
-
-.thread-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.thread-item {
-  display: grid;
-  grid-template-columns: 74px minmax(0, 1fr);
-  gap: 18px;
-  padding: 18px 0;
-  border-bottom: 1px solid var(--border-soft, rgba(137, 158, 181, 0.22));
-}
-
-.thread-thumbnail {
-  width: 64px;
-  height: 64px;
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  background: linear-gradient(145deg, #6478ff, #1d222a);
-  color: #ffffff;
-  font-size: 1.25rem;
-  font-weight: 800;
-}
-
-.thread-content {
   min-width: 0;
 }
 
-.thread-meta {
+
+/* =========================================================
+   PROFILE ACTIVITY AREA
+   Shared container for Overview, Posts, Comments, Saved,
+   and Study Buddy tabs.
+   ========================================================= */
+
+.profile-activity-list {
   display: flex;
-  align-items: center;
-  gap: 7px;
-  margin: 0 0 6px;
-  color: var(--text-muted, #9ba8b6);
-  font-size: 0.82rem;
+  flex-direction: column;
+  min-width: 0;
 }
 
-.thread-meta span:first-child {
+.profile-forum-feed {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+
+/* =========================================================
+   PROFILE ACTIVITY CARDS
+   Forum-style list cards used for posts, comments, saved
+   items, and Study Buddy sessions.
+   ========================================================= */
+
+.profile-thread-card {
+  padding: 18px 8px;
+  border-bottom: 1px solid var(--border-soft, rgba(137, 158, 181, 0.22));
+  transition: background 0.14s ease;
+}
+
+.profile-thread-card:first-child {
+  padding-top: 12px;
+}
+
+.profile-thread-card:hover {
+  background: rgba(137, 158, 181, 0.08);
+}
+
+.profile-thread-content {
+  min-width: 0;
+}
+
+.profile-thread-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  color: var(--text-muted, #9ba8b6);
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.profile-thread-category {
   color: var(--text-main, #f5f7fb);
   font-weight: 800;
 }
 
-.thread-title {
-  margin: 0 0 12px;
-  color: var(--text-main, #f5f7fb);
-  font-size: 1.05rem;
-  line-height: 1.35;
-  letter-spacing: -0.01em;
+.profile-thread-dot {
+  color: rgba(169, 186, 203, 0.65);
 }
 
-.thread-actions {
+.profile-thread-title {
+  display: inline-block;
+  margin-top: 8px;
+  color: var(--text-main, #f5f7fb);
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+  text-decoration: none;
+}
+
+.profile-thread-title:hover {
+  color: #93c5fd;
+}
+
+.profile-thread-body {
+  width: 100%;
+  margin: 12px 0 0;
+  color: var(--text-soft, #cbd4df);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+.profile-thread-footer {
+  margin-top: 12px;
+}
+
+.profile-thread-actions {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 10px;
   color: var(--text-muted, #9ba8b6);
   font-size: 0.86rem;
   font-weight: 700;
 }
 
-.thread-actions a {
+.profile-thread-action {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: transparent;
   color: inherit;
+  line-height: 1;
   text-decoration: none;
 }
 
-.thread-actions a:hover,
-.thread-actions span:hover {
+.profile-thread-action:hover {
+  background: rgba(137, 158, 181, 0.12);
   color: var(--text-main, #f5f7fb);
 }
 
 
-/* =========================
+/* =========================================================
+   EMPTY STATES
+   Used when a profile tab has no matching activity.
+   ========================================================= */
+
+.profile-empty-card {
+  padding: 22px 8px;
+  border-bottom: 1px solid var(--border-soft, rgba(137, 158, 181, 0.22));
+}
+
+.profile-empty-card h2 {
+  margin: 0 0 8px;
+  color: var(--text-main, #f5f7fb);
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+}
+
+.profile-empty-card p {
+  margin: 0;
+  color: var(--text-muted, #9ba8b6);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+
+/* =========================================================
+   PROFILE FILTER SUBTABS
+   Small filters inside Saved and Study Buddy tabs.
+   ========================================================= */
+
+.profile-subtabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 10px;
+  padding: 0 0 6px;
+}
+
+.profile-subtab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  padding: 7px 14px;
+  border: 1px solid rgba(137, 158, 181, 0.22);
+  border-radius: 999px;
+  background: rgba(17, 19, 21, 0.65);
+  color: var(--text-soft, #cbd4df);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.profile-subtab:hover,
+.profile-subtab.is-active {
+  border-color: rgba(100, 120, 255, 0.55);
+  background: rgba(100, 120, 255, 0.18);
+  color: #ffffff;
+}
+
+
+/* =========================================================
    SIDEBAR CARDS
-========================= */
+   Right-side profile summary and statistics cards.
+   ========================================================= */
 
 .profile-card {
   overflow: hidden;
@@ -304,9 +391,17 @@
   margin: 0;
   color: var(--text-muted, #9ba8b6);
   font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.profile-side-meta + .profile-side-meta {
+  margin-top: 8px;
 }
 
 .profile-share-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin-top: 18px;
   border: 0;
   border-radius: 999px;
@@ -315,6 +410,7 @@
   color: #ffffff;
   font-size: 0.86rem;
   font-weight: 800;
+  text-decoration: none;
   cursor: pointer;
 }
 
@@ -323,9 +419,14 @@
 }
 
 
-/* =========================
+/* =========================================================
    STATS CARD
-========================= */
+   User activity statistics shown in the sidebar.
+   ========================================================= */
+
+.profile-stats-card .profile-card-banner {
+  height: 128px;
+}
 
 .profile-stats-list {
   display: grid;
@@ -336,58 +437,44 @@
   margin: 0;
   color: var(--text-main, #f5f7fb);
   font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .profile-stats-list strong {
-  margin-right: 4px;
+  margin-right: 6px;
+  color: #ffffff;
+  font-size: 1rem;
   font-weight: 800;
 }
 
-
-/* =========================
-   ACHIEVEMENTS CARD
-========================= */
-
-.achievement-icons {
-  display: flex;
-  gap: 12px;
-}
-
-.achievement-icons span {
-  width: 38px;
-  height: 38px;
-  border-radius: 999px;
-  display: grid;
-  place-items: center;
-  background: rgba(94, 118, 255, 0.16);
-  font-size: 1.1rem;
+.profile-stats-list span {
+  color: var(--text-main, #f5f7fb);
+  font-weight: 600;
 }
 
 
-/* =========================
-   RESPONSIVE
-========================= */
+/* =========================================================
+   RESPONSIVE LAYOUT
+   Adjusts the profile page for tablets and small screens.
+   ========================================================= */
 
 @media (max-width: 1100px) {
-  .profile-header,
-  .profile-tabs {
-    width: 100%;
-  }
-
   .profile-layout {
     grid-template-columns: 1fr;
   }
 
   .profile-sidebar {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    margin-top: 0;
+  }
+
+  .profile-settings-link {
+    margin-left: 0;
   }
 }
 
 @media (max-width: 760px) {
   .profile-header {
-    min-height: auto;
-    padding: 28px 0 24px;
+    padding: 28px 0 18px;
   }
 
   .profile-identity {
@@ -406,23 +493,17 @@
     padding: 20px 0;
   }
 
-  .thread-item {
-    grid-template-columns: 56px minmax(0, 1fr);
-    gap: 14px;
+  .profile-thread-card {
+    padding: 16px 4px;
   }
 
-  .thread-thumbnail {
-    width: 52px;
-    height: 52px;
-  }
-
-  .thread-title {
+  .profile-thread-title {
     font-size: 0.98rem;
   }
 
-  .thread-actions {
-    gap: 12px;
-    font-size: 0.8rem;
+  .profile-thread-actions {
+    gap: 8px;
+    font-size: 0.82rem;
   }
 
   .profile-sidebar {
@@ -431,8 +512,26 @@
 }
 
 @media (max-width: 520px) {
-  .profile-create-row {
-    align-items: flex-start;
-    flex-direction: column;
+  .profile-tabs {
+    align-items: stretch;
+  }
+
+  .profile-tab,
+  .profile-settings-link {
+    padding: 8px 14px;
+    font-size: 0.86rem;
+  }
+
+  .profile-subtabs {
+    gap: 8px;
+  }
+
+  .profile-subtab {
+    padding: 6px 12px;
+    font-size: 0.82rem;
+  }
+
+  .profile-card-body {
+    padding: 18px;
   }
 }

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", function () {
     if (isValid) {
       field.classList.add("is-valid");
       feedback.classList.add("is-success");
-      status.textContent = "OK";
+      status.textContent = "✓";
     } else {
       field.classList.add("is-invalid");
       feedback.classList.add("is-error");

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -56,7 +56,7 @@
             aria-controls="login-password"
             data-password-toggle
         >
-            Show
+            👁
         </button>
       </div>
 

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -40,7 +40,7 @@
           </label>
 
           <span class="field-status" data-username-status aria-hidden="true">
-            {% if field_errors.username %}!{% elif field_success.username %}OK{% endif %}
+            {% if field_errors.username %}!{% elif field_success.username %}✓{% endif %}
           </span>
         </div>
 
@@ -124,7 +124,7 @@
 						aria-controls="register-password"
 						data-password-toggle
 					>
-						Show
+						👁
 					</button>
 				</div>
 
@@ -169,7 +169,7 @@
             aria-controls="confirm-password"
             data-password-toggle
           >
-            Show
+            👁
           </button>
         </div>
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -134,11 +134,6 @@
             </a>
 
             <a href="#" class="profile-menu-item">
-              <i class="bi bi-trophy" aria-hidden="true"></i>
-              <span>Achievements</span>
-            </a>
-
-            <a href="#" class="profile-menu-item">
               <i class="bi bi-gear" aria-hidden="true"></i>
               <span>Settings</span>
             </a>

--- a/app/templates/forum.html
+++ b/app/templates/forum.html
@@ -137,13 +137,6 @@
             <div class="thread-content">
 
               <div class="thread-meta">
-                {% if thread.is_pinned %}
-                  <span class="thread-pinned">
-                    <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
-                    Pinned
-                  </span>
-                  <span class="thread-dot">·</span>
-                {% endif %}
 
                 <span class="thread-category">{{ thread.category }}</span>
                 <span class="thread-dot">·</span>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -6,6 +6,126 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
 {% endblock %}
 
+
+{# =========================================================
+   Reusable forum-style activity card for forum threads.
+   Used in Posts and Saved tabs.
+   ========================================================= #}
+{% macro forum_thread_card(thread, label="Forum", show_author=True) %}
+  <article class="profile-thread-card">
+    <div class="profile-thread-content">
+
+      <div class="profile-thread-meta">
+        <span class="profile-thread-category">{{ label }}</span>
+
+        {% if thread.category %}
+          <span class="profile-thread-dot">·</span>
+          <span>{{ thread.category }}</span>
+        {% endif %}
+
+        {% if show_author %}
+          <span class="profile-thread-dot">·</span>
+          <span>
+            Posted by {{ thread.author.display_name if thread.author else "Unknown user" }}
+          </span>
+        {% endif %}
+
+        {% if thread.created_at %}
+          <span class="profile-thread-dot">·</span>
+          <span>{{ thread.created_at|forum_time }}</span>
+        {% endif %}
+      </div>
+
+      <a href="{{ url_for('main.thread_detail', thread_id=thread.id) }}"
+         class="profile-thread-title">
+        {{ thread.title }}
+      </a>
+
+      <div class="profile-thread-footer">
+        <div class="profile-thread-actions">
+          <span class="profile-thread-action">
+            <i class="bi bi-hand-thumbs-up" aria-hidden="true"></i>
+            {{ thread.like_count }}
+          </span>
+
+          <a href="{{ url_for('main.thread_detail', thread_id=thread.id) }}#comments"
+             class="profile-thread-action">
+            <i class="bi bi-chat" aria-hidden="true"></i>
+            {{ thread.reply_count }} comments
+          </a>
+
+          <a href="{{ url_for('main.thread_detail', thread_id=thread.id) }}"
+             class="profile-thread-action">
+            View thread
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </article>
+{% endmacro %}
+
+
+{# =========================================================
+   Reusable forum-style activity card for Study Buddy sessions.
+   Used in Saved and Study Buddy tabs.
+   ========================================================= #}
+{% macro study_session_card(study_session, role_label=None) %}
+  <article class="profile-thread-card">
+    <div class="profile-thread-content">
+
+      <div class="profile-thread-meta">
+        <span class="profile-thread-category">Study Buddy</span>
+
+        {% if role_label %}
+          <span class="profile-thread-dot">·</span>
+          <span>{{ role_label }}</span>
+        {% endif %}
+
+        <span class="profile-thread-dot">·</span>
+        <span>
+          {% if study_session.session_date %}
+            {{ study_session.session_date.strftime("%d %b %Y") }}
+          {% else %}
+            Date TBA
+          {% endif %}
+        </span>
+      </div>
+
+      <a href="{{ url_for('main.session_detail', session_id=study_session.id) }}"
+         class="profile-thread-title">
+        {{ study_session.topic }}
+      </a>
+
+      <div class="profile-thread-footer">
+        <div class="profile-thread-actions">
+          <span class="profile-thread-action">
+            <i class="bi bi-journal-code" aria-hidden="true"></i>
+            {{ study_session.unit_code }}
+          </span>
+
+          <span class="profile-thread-action">
+            <i class="bi bi-geo-alt" aria-hidden="true"></i>
+            {{ study_session.mode.replace("-", " ").title() if study_session.mode else "Mode TBA" }}
+          </span>
+
+          <span class="profile-thread-action">
+            <i class="bi bi-people" aria-hidden="true"></i>
+            {{ study_session.joined_count }}/{{ study_session.capacity }} joined
+          </span>
+
+          <a href="{{ url_for('main.session_detail', session_id=study_session.id) }}"
+             class="profile-thread-action">
+            View session
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </article>
+{% endmacro %}
+
+
 {% block content %}
 <section class="profile-page">
 
@@ -25,144 +145,272 @@
       <div class="profile-heading">
         <h1 class="profile-name">{{ current_user.display_name }}</h1>
         <p class="profile-username">@{{ current_user.username }}</p>
+
         {% if current_user.bio %}
-          <p class="profile-username">{{ current_user.bio }}</p>
+          <p class="profile-bio">{{ current_user.bio }}</p>
         {% endif %}
       </div>
     </div>
   </header>
 
-  <!-- Profile tabs -->
+  <!-- Profile navigation -->
   <nav class="profile-tabs" aria-label="Profile sections">
-    <a href="#" class="profile-tab is-active">Overview</a>
-    <a href="#" class="profile-tab">Posts</a>
-    <a href="#" class="profile-tab">Comments</a>
-    <a href="#" class="profile-tab">Saved</a>
-    <a href="#" class="profile-tab">Study Buddy</a>
+    <a href="{{ url_for('main.profile', tab='overview') }}"
+       class="profile-tab {% if active_tab == 'overview' %}is-active{% endif %}">
+      Overview
+    </a>
+
+    <a href="{{ url_for('main.profile', tab='posts') }}"
+       class="profile-tab {% if active_tab == 'posts' %}is-active{% endif %}">
+      Posts
+    </a>
+
+    <a href="{{ url_for('main.profile', tab='comments') }}"
+       class="profile-tab {% if active_tab == 'comments' %}is-active{% endif %}">
+      Comments
+    </a>
+
+    <a href="{{ url_for('main.profile', tab='saved') }}"
+       class="profile-tab {% if active_tab == 'saved' %}is-active{% endif %}">
+      Saved
+    </a>
+
+    <a href="{{ url_for('main.profile', tab='studybuddy') }}"
+       class="profile-tab {% if active_tab == 'studybuddy' %}is-active{% endif %}">
+      Study Buddy
+    </a>
   </nav>
 
   <div class="profile-layout">
 
-    <!-- Main content -->
+    <!-- Main profile activity area -->
     <main class="profile-main">
+      <section class="profile-activity-list" aria-label="Profile activity">
 
-      <div class="profile-create-row">
-        <a href="#" class="create-post-button">
-          <span>+</span>
-          Create Post
-        </a>
+        <!-- Overview tab -->
+        {% if active_tab == "overview" %}
 
-        <button class="compact-icon-button" type="button" aria-label="Post filters">
-          ⚙
-        </button>
-      </div>
+          {% if recent_activity %}
+            <div class="profile-forum-feed">
+              {% for item in recent_activity %}
+                <article class="profile-thread-card">
+                  <div class="profile-thread-content">
 
-      <section class="thread-list" aria-label="Profile activity">
+                    <div class="profile-thread-meta">
+                      <span class="profile-thread-category">{{ item.type }}</span>
+                      <span class="profile-thread-dot">·</span>
+                      <span>{{ item.created_at|forum_time }}</span>
+                    </div>
 
-        <article class="thread-item">
-          <div class="thread-thumbnail">Q</div>
+                    <a href="{{ item.url }}" class="profile-thread-title">
+                      {{ item.title }}
+                    </a>
 
-          <div class="thread-content">
-            <p class="thread-meta">
-              <span>Forum</span>
-              <span>·</span>
-              <span>2h ago</span>
-            </p>
+                    <div class="profile-thread-footer">
+                      <div class="profile-thread-actions">
+                        <span class="profile-thread-action">{{ item.meta }}</span>
+                      </div>
+                    </div>
 
-            <h2 class="thread-title">
-              How do I connect Flask routes with HTML templates?
-            </h2>
-
-            <div class="thread-actions">
-              <span>↑ 4</span>
-              <span>💬 2 comments</span>
-              <a href="#">Save</a>
-              <a href="#">Share</a>
+                  </div>
+                </article>
+              {% endfor %}
             </div>
-          </div>
-        </article>
+          {% else %}
+            <article class="profile-empty-card">
+              <h2>No activity yet</h2>
+              <p>Your posts, comments, and Study Buddy activity will appear here.</p>
+            </article>
+          {% endif %}
 
-        <article class="thread-item">
-          <div class="thread-thumbnail">S</div>
+        <!-- Posts tab -->
+        {% elif active_tab == "posts" %}
 
-          <div class="thread-content">
-            <p class="thread-meta">
-              <span>Study Buddy</span>
-              <span>·</span>
-              <span>Yesterday</span>
-            </p>
-
-            <h2 class="thread-title">
-              Looking for a study partner for CITS5505 revision
-            </h2>
-
-            <div class="thread-actions">
-              <span>↑ 8</span>
-              <span>💬 5 comments</span>
-              <a href="#">Save</a>
-              <a href="#">Share</a>
+          {% if user_posts %}
+            <div class="profile-forum-feed">
+              {% for thread in user_posts %}
+                {{ forum_thread_card(thread, "Forum", False) }}
+              {% endfor %}
             </div>
-          </div>
-        </article>
+          {% else %}
+            <article class="profile-empty-card">
+              <h2>No posts yet</h2>
+              <p>Forum posts you create will appear here.</p>
+            </article>
+          {% endif %}
 
-        <article class="thread-item">
-          <div class="thread-thumbnail">N</div>
+        <!-- Comments tab -->
+        {% elif active_tab == "comments" %}
 
-          <div class="thread-content">
-            <p class="thread-meta">
-              <span>News</span>
-              <span>·</span>
-              <span>3d ago</span>
-            </p>
+          {% if user_comments %}
+            <div class="profile-forum-feed">
+              {% for reply in user_comments %}
+                <article class="profile-thread-card">
+                  <div class="profile-thread-content">
 
-            <h2 class="thread-title">
-              Useful resources for learning frontend accessibility
-            </h2>
+                    <div class="profile-thread-meta">
+                      <span class="profile-thread-category">Comment</span>
 
-            <div class="thread-actions">
-              <span>↑ 12</span>
-              <span>💬 3 comments</span>
-              <a href="#">Save</a>
-              <a href="#">Share</a>
+                      {% if reply.created_at %}
+                        <span class="profile-thread-dot">·</span>
+                        <span>{{ reply.created_at|forum_time }}</span>
+                      {% endif %}
+                    </div>
+
+                    <a href="{{ url_for('main.thread_detail', thread_id=reply.thread_id) }}"
+                       class="profile-thread-title">
+                      {{ reply.thread.title if reply.thread else "Forum thread" }}
+                    </a>
+
+                    <p class="profile-thread-body">
+                      {{ reply.body[:180] }}{% if reply.body|length > 180 %}...{% endif %}
+                    </p>
+
+                    <div class="profile-thread-footer">
+                      <div class="profile-thread-actions">
+                        <a href="{{ url_for('main.thread_detail', thread_id=reply.thread_id) }}"
+                           class="profile-thread-action">
+                          View thread
+                        </a>
+                      </div>
+                    </div>
+
+                  </div>
+                </article>
+              {% endfor %}
             </div>
+          {% else %}
+            <article class="profile-empty-card">
+              <h2>No comments yet</h2>
+              <p>Forum comments and replies you write will appear here.</p>
+            </article>
+          {% endif %}
+
+        <!-- Saved tab -->
+        {% elif active_tab == "saved" %}
+
+          <div class="profile-subtabs" aria-label="Saved item filters">
+            <a href="{{ url_for('main.profile', tab='saved', saved='all') }}"
+               class="profile-subtab {% if saved_filter == 'all' %}is-active{% endif %}">
+              All
+            </a>
+
+            <a href="{{ url_for('main.profile', tab='saved', saved='posts') }}"
+               class="profile-subtab {% if saved_filter == 'posts' %}is-active{% endif %}">
+              Posts
+            </a>
+
+            <a href="{{ url_for('main.profile', tab='saved', saved='sessions') }}"
+               class="profile-subtab {% if saved_filter == 'sessions' %}is-active{% endif %}">
+              Sessions
+            </a>
           </div>
-        </article>
+
+          {% if saved_items %}
+            <div class="profile-forum-feed">
+              {% for item in saved_items %}
+
+                {% if item.kind == "post" %}
+                  {{ forum_thread_card(item.thread, "Forum", True) }}
+
+                {% elif item.kind == "session" %}
+                  {{ study_session_card(item.session) }}
+
+                {% endif %}
+
+              {% endfor %}
+            </div>
+          {% else %}
+            <article class="profile-empty-card">
+              <h2>No saved items yet</h2>
+
+              {% if saved_filter == "posts" %}
+                <p>Saved forum posts will appear here.</p>
+              {% elif saved_filter == "sessions" %}
+                <p>Saved Study Buddy sessions will appear here.</p>
+              {% else %}
+                <p>Saved forum posts and Study Buddy sessions will appear here.</p>
+              {% endif %}
+            </article>
+          {% endif %}
+
+        <!-- Study Buddy tab -->
+        {% elif active_tab == "studybuddy" %}
+
+          <div class="profile-subtabs" aria-label="Study Buddy filters">
+            <a href="{{ url_for('main.profile', tab='studybuddy', studybuddy='all') }}"
+               class="profile-subtab {% if studybuddy_filter == 'all' %}is-active{% endif %}">
+              All
+            </a>
+
+            <a href="{{ url_for('main.profile', tab='studybuddy', studybuddy='hosted') }}"
+               class="profile-subtab {% if studybuddy_filter == 'hosted' %}is-active{% endif %}">
+              Hosted
+            </a>
+
+            <a href="{{ url_for('main.profile', tab='studybuddy', studybuddy='joined') }}"
+               class="profile-subtab {% if studybuddy_filter == 'joined' %}is-active{% endif %}">
+              Joined
+            </a>
+          </div>
+
+          {% if studybuddy_items %}
+            <div class="profile-forum-feed">
+              {% for item in studybuddy_items %}
+                {{ study_session_card(item.session, item.role ~ " session") }}
+              {% endfor %}
+            </div>
+          {% else %}
+            <article class="profile-empty-card">
+              <h2>No Study Buddy sessions yet</h2>
+
+              {% if studybuddy_filter == "hosted" %}
+                <p>Sessions you host will appear here.</p>
+              {% elif studybuddy_filter == "joined" %}
+                <p>Sessions you join will appear here.</p>
+              {% else %}
+                <p>Sessions you host or join will appear here.</p>
+              {% endif %}
+            </article>
+          {% endif %}
+
+        {% endif %}
 
       </section>
-
     </main>
 
     <!-- Right sidebar -->
     <aside class="profile-sidebar">
 
-      <section class="profile-card">
+      <section class="profile-card profile-stats-card">
         <div class="profile-card-banner"></div>
 
-        <div class="profile-card-body">
-          <h2 class="profile-card-title">Profile</h2>
-
-          <h3 class="profile-side-name">{{ current_user.display_name }}</h3>
-          <p class="profile-side-meta">@{{ current_user.username }}</p>
-
-          <button class="profile-share-button" type="button">
-            Share
-          </button>
-        </div>
-      </section>
-
-      <section class="profile-card">
         <div class="profile-card-body">
           <h2 class="profile-card-title">Stats</h2>
 
           <div class="profile-stats-list">
-            <p><strong>{{ post_count }}</strong> Posts</p>
-            <p><strong>{{ comment_count }}</strong> Comments</p>
-            <p><strong>{{ hosted_count }}</strong> Hosted Sessions</p>
-            <p><strong>{{ joined_count }}</strong> Joined Sessions</p>
+            <p>
+              <strong>{{ post_count }}</strong>
+              <span>Posts</span>
+            </p>
+
+            <p>
+              <strong>{{ comment_count }}</strong>
+              <span>Comments</span>
+            </p>
+
+            <p>
+              <strong>{{ hosted_count }}</strong>
+              <span>Hosted Sessions</span>
+            </p>
+
+            <p>
+              <strong>{{ joined_count }}</strong>
+              <span>Joined Sessions</span>
+            </p>
           </div>
         </div>
       </section>
-
 
     </aside>
 

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -152,25 +152,14 @@
           <h2 class="profile-card-title">Stats</h2>
 
           <div class="profile-stats-list">
-            <p><strong>0</strong> Posts</p>
-            <p><strong>0</strong> Comments</p>
-            <p><strong>0</strong> Study groups</p>
-            <p><strong>1</strong> Achievements</p>
+            <p><strong>{{ post_count }}</strong> Posts</p>
+            <p><strong>{{ comment_count }}</strong> Comments</p>
+            <p><strong>{{ hosted_count }}</strong> Hosted Sessions</p>
+            <p><strong>{{ joined_count }}</strong> Joined Sessions</p>
           </div>
         </div>
       </section>
 
-      <section class="profile-card">
-        <div class="profile-card-body">
-          <h2 class="profile-card-title">Achievements</h2>
-
-          <div class="achievement-icons">
-            <span>🎓</span>
-            <span>🔥</span>
-            <span>💡</span>
-          </div>
-        </div>
-      </section>
 
     </aside>
 


### PR DESCRIPTION
## Summary
This PR adds the project README and connects the profile page tabs to real user activity.

## Changes
- Added a root `README.md` with:
  - application purpose, design, and use
  - group member table
  - launch instructions
  - test instructions
- Connected profile tabs to real user activity:
  - Overview
  - Posts
  - Comments
  - Saved
  - Study Buddy
- Added Saved filters:
  - All
  - Posts
  - Sessions
- Added Study Buddy filters:
  - All
  - Hosted
  - Joined
- Reused a forum-style card layout for profile activity
- Removed placeholder profile content

## Testing
- Checked `/profile`
- Checked `/profile?tab=posts`
- Checked `/profile?tab=comments`
- Checked `/profile?tab=saved`
- Checked `/profile?tab=saved&saved=posts`
- Checked `/profile?tab=saved&saved=sessions`
- Checked `/profile?tab=studybuddy`
- Checked `/profile?tab=studybuddy&studybuddy=hosted`
- Checked `/profile?tab=studybuddy&studybuddy=joined`